### PR TITLE
SDK-3306: Export common error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   thrown upon reception of an HTTP error response, i.e. 4xx and 5xx ranges. The two
   associated type guards are available to test for the presence of the specific properties
   exposed by the class.
-- `BadRequestError`, `ConflictError`, `ForbiddenError`, `GoneError`, `InternalServerErrorError`,
+- `BadRequestError`, `ConflictError`, `ForbiddenError`, `GoneError`, `InternalServerError`,
   `MethodNotAllowedError`, `NotAcceptableError`, `NotFoundError`, `PreconditionFailedError`,
   `TooManyRequestsError`, `UnauthorizedError`, `UnsupportedMediaTypeError`: Specializations
   of the `ClientHttpError` to represent common HTTP error responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,5 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   `MethodNotAllowedError`, `NotAcceptableError`, `NotFoundError`, `PreconditionFailedError`,
   `TooManyRequestsError`, `UnauthorizedError`, `UnsupportedMediaTypeError`: Specializations
   of the `ClientHttpError` to represent common HTTP error responses.
+- `handleErrorResponse`: a function to map the received HTTP error to the appropriate error
+  class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased changes
 
--
+### New Features
+
+- `InruptClientError`: Superclass for all Inrupt client libraries runtime errors.
+- `ClientHttpError`, `hasProblemDetails`, `hasErrorResponse`: Class for runtime error
+  thrown upon reception of an HTTP error response, i.e. 4xx and 5xx ranges. The two
+  associated type guards are available to test for the presence of the specific properties
+  exposed by the class.
+- `BadRequestError`, `ConflictError`, `ForbiddenError`, `GoneError`, `InternalServerErrorError`,
+  `MethodNotAllowedError`, `NotAcceptableError`, `NotFoundError`, `PreconditionFailedError`,
+  `TooManyRequestsError`, `UnauthorizedError`, `UnsupportedMediaTypeError`: Specializations
+  of the `ClientHttpError` to represent common HTTP error responses.

--- a/src/http/handleErrorResponse.test.ts
+++ b/src/http/handleErrorResponse.test.ts
@@ -1,0 +1,77 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { handleErrorResponse } from "./handleErrorResponse";
+import {
+  BadRequestError,
+  BAD_REQUEST_STATUS,
+} from "./wellKnown/badRequestError";
+import { mockResponse } from "./httpError.mock";
+import ConflictError, { CONFLICT_STATUS } from "./wellKnown/conflictError";
+import ForbiddenError, { FORBIDDEN_STATUS } from "./wellKnown/forbiddenError";
+import GoneError, { GONE_STATUS } from "./wellKnown/goneError";
+import InternalServerErrorError, {
+  INTERNAL_SERVER_ERROR_STATUS,
+} from "./wellKnown/internalServerErrorError";
+import MethodNotAllowedError, {
+  METHOD_NOT_ALLOWED_STATUS,
+} from "./wellKnown/methodNotAllowedError";
+import NotAcceptableError, {
+  NOT_ACCEPTABLE_STATUS,
+} from "./wellKnown/notAcceptableError";
+import NotFoundError, { NOT_FOUND_STATUS } from "./wellKnown/notFoundError";
+import PreconditionFailedError, {
+  PRECONDITION_FAILED_STATUS,
+} from "./wellKnown/preconditionFailedError";
+import TooManyRequestsError, {
+  TOO_MANY_REQUESTS_STATUS,
+} from "./wellKnown/tooManyRequestsError";
+import UnauthorizedError, {
+  UNAUTHORIZED_STATUS,
+} from "./wellKnown/unauthorizedError";
+import UnsupportedMediaTypeError, {
+  UNSUPPORTED_MEDIA_TYPE_STATUS,
+} from "./wellKnown/unsupportedMediaTypeError";
+
+describe("handleErrorResponse", () => {
+  it.each([
+    [BAD_REQUEST_STATUS, BadRequestError],
+    [CONFLICT_STATUS, ConflictError],
+    [FORBIDDEN_STATUS, ForbiddenError],
+    [GONE_STATUS, GoneError],
+    [INTERNAL_SERVER_ERROR_STATUS, InternalServerErrorError],
+    [METHOD_NOT_ALLOWED_STATUS, MethodNotAllowedError],
+    [NOT_ACCEPTABLE_STATUS, NotAcceptableError],
+    [NOT_FOUND_STATUS, NotFoundError],
+    [PRECONDITION_FAILED_STATUS, PreconditionFailedError],
+    [TOO_MANY_REQUESTS_STATUS, TooManyRequestsError],
+    [UNAUTHORIZED_STATUS, UnauthorizedError],
+    [UNSUPPORTED_MEDIA_TYPE_STATUS, UnsupportedMediaTypeError],
+  ])("maps %i status to %s class", (responseStatus, errorClass) => {
+    const response = mockResponse({ status: responseStatus });
+    const error = handleErrorResponse(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(error).toBeInstanceOf(errorClass);
+  });
+});

--- a/src/http/handleErrorResponse.test.ts
+++ b/src/http/handleErrorResponse.test.ts
@@ -28,9 +28,9 @@ import { mockResponse } from "./httpError.mock";
 import ConflictError, { CONFLICT_STATUS } from "./wellKnown/conflictError";
 import ForbiddenError, { FORBIDDEN_STATUS } from "./wellKnown/forbiddenError";
 import GoneError, { GONE_STATUS } from "./wellKnown/goneError";
-import InternalServerErrorError, {
+import InternalServerError, {
   INTERNAL_SERVER_ERROR_STATUS,
-} from "./wellKnown/internalServerErrorError";
+} from "./wellKnown/internalServerError";
 import MethodNotAllowedError, {
   METHOD_NOT_ALLOWED_STATUS,
 } from "./wellKnown/methodNotAllowedError";
@@ -58,7 +58,7 @@ describe("handleErrorResponse", () => {
     [CONFLICT_STATUS, ConflictError],
     [FORBIDDEN_STATUS, ForbiddenError],
     [GONE_STATUS, GoneError],
-    [INTERNAL_SERVER_ERROR_STATUS, InternalServerErrorError],
+    [INTERNAL_SERVER_ERROR_STATUS, InternalServerError],
     [METHOD_NOT_ALLOWED_STATUS, MethodNotAllowedError],
     [NOT_ACCEPTABLE_STATUS, NotAcceptableError],
     [NOT_FOUND_STATUS, NotFoundError],

--- a/src/http/handleErrorResponse.test.ts
+++ b/src/http/handleErrorResponse.test.ts
@@ -50,6 +50,7 @@ import UnauthorizedError, {
 import UnsupportedMediaTypeError, {
   UNSUPPORTED_MEDIA_TYPE_STATUS,
 } from "./wellKnown/unsupportedMediaTypeError";
+import ClientHttpError from "./httpError";
 
 describe("handleErrorResponse", () => {
   it.each([
@@ -65,6 +66,8 @@ describe("handleErrorResponse", () => {
     [TOO_MANY_REQUESTS_STATUS, TooManyRequestsError],
     [UNAUTHORIZED_STATUS, UnauthorizedError],
     [UNSUPPORTED_MEDIA_TYPE_STATUS, UnsupportedMediaTypeError],
+    // Defaults to ClientHttpError for any other status code
+    [499, ClientHttpError],
   ])("maps %i status to %s class", (responseStatus, errorClass) => {
     const response = mockResponse({ status: responseStatus });
     const error = handleErrorResponse(
@@ -73,5 +76,12 @@ describe("handleErrorResponse", () => {
       "Some error message",
     );
     expect(error).toBeInstanceOf(errorClass);
+  });
+
+  it("throws on non-error response", () => {
+    const response = mockResponse({ status: 200 });
+    expect(() => {
+      handleErrorResponse(response, "Some response body", "Some error message");
+    }).toThrow();
   });
 });

--- a/src/http/handleErrorResponse.ts
+++ b/src/http/handleErrorResponse.ts
@@ -87,11 +87,7 @@ export function handleErrorResponse(
     case GONE_STATUS:
       return new GoneError(responseMetadata, responseBody, message);
     case INTERNAL_SERVER_ERROR_STATUS:
-      return new InternalServerError(
-        responseMetadata,
-        responseBody,
-        message,
-      );
+      return new InternalServerError(responseMetadata, responseBody, message);
     case METHOD_NOT_ALLOWED_STATUS:
       return new MethodNotAllowedError(responseMetadata, responseBody, message);
     case NOT_ACCEPTABLE_STATUS:

--- a/src/http/handleErrorResponse.ts
+++ b/src/http/handleErrorResponse.ts
@@ -25,9 +25,9 @@ import BadRequestError, {
 import ConflictError, { CONFLICT_STATUS } from "./wellKnown/conflictError";
 import ForbiddenError, { FORBIDDEN_STATUS } from "./wellKnown/forbiddenError";
 import GoneError, { GONE_STATUS } from "./wellKnown/goneError";
-import InternalServerErrorError, {
+import InternalServerError, {
   INTERNAL_SERVER_ERROR_STATUS,
-} from "./wellKnown/internalServerErrorError";
+} from "./wellKnown/internalServerError";
 import MethodNotAllowedError, {
   METHOD_NOT_ALLOWED_STATUS,
 } from "./wellKnown/methodNotAllowedError";
@@ -87,7 +87,7 @@ export function handleErrorResponse(
     case GONE_STATUS:
       return new GoneError(responseMetadata, responseBody, message);
     case INTERNAL_SERVER_ERROR_STATUS:
-      return new InternalServerErrorError(
+      return new InternalServerError(
         responseMetadata,
         responseBody,
         message,

--- a/src/http/handleErrorResponse.ts
+++ b/src/http/handleErrorResponse.ts
@@ -1,0 +1,122 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { ClientHttpError } from "./httpError";
+import BadRequestError, {
+  BAD_REQUEST_STATUS,
+} from "./wellKnown/badRequestError";
+import ConflictError, { CONFLICT_STATUS } from "./wellKnown/conflictError";
+import ForbiddenError, { FORBIDDEN_STATUS } from "./wellKnown/forbiddenError";
+import GoneError, { GONE_STATUS } from "./wellKnown/goneError";
+import InternalServerErrorError, {
+  INTERNAL_SERVER_ERROR_STATUS,
+} from "./wellKnown/internalServerErrorError";
+import MethodNotAllowedError, {
+  METHOD_NOT_ALLOWED_STATUS,
+} from "./wellKnown/methodNotAllowedError";
+import NotAcceptableError, {
+  NOT_ACCEPTABLE_STATUS,
+} from "./wellKnown/notAcceptableError";
+import NotFoundError, { NOT_FOUND_STATUS } from "./wellKnown/notFoundError";
+import PreconditionFailedError, {
+  PRECONDITION_FAILED_STATUS,
+} from "./wellKnown/preconditionFailedError";
+import TooManyRequestsError, {
+  TOO_MANY_REQUESTS_STATUS,
+} from "./wellKnown/tooManyRequestsError";
+import UnauthorizedError, {
+  UNAUTHORIZED_STATUS,
+} from "./wellKnown/unauthorizedError";
+import UnsupportedMediaTypeError, {
+  UNSUPPORTED_MEDIA_TYPE_STATUS,
+} from "./wellKnown/unsupportedMediaTypeError";
+
+/**
+ * Map an HTTP error response to one of the Error classes exported by this library.
+ *
+ * @example
+ * ```ts
+ * const response = await fetch("https://example.org/resource");
+ * if (!response.ok) {
+ *   const responseBody = await response.text();
+ *   throw handleErrorResponse(response, responseBody, "Fetch got error response");
+ * }
+ * ```
+ *
+ * @param responseMetadata the response metadata
+ * @param responseBody the response body
+ * @param message the error message
+ * @returns an instance of the ClientHttpError subclass matching the response metadata status.
+ * If the response status is unkown, the generic ClientHttpError class is used.
+ * @since unreleased
+ */
+export function handleErrorResponse(
+  responseMetadata: {
+    status: number;
+    statusText: string;
+    headers: Headers;
+    url: string;
+  },
+  responseBody: string,
+  message: string,
+): ClientHttpError {
+  switch (responseMetadata.status) {
+    case BAD_REQUEST_STATUS:
+      return new BadRequestError(responseMetadata, responseBody, message);
+    case CONFLICT_STATUS:
+      return new ConflictError(responseMetadata, responseBody, message);
+    case FORBIDDEN_STATUS:
+      return new ForbiddenError(responseMetadata, responseBody, message);
+    case GONE_STATUS:
+      return new GoneError(responseMetadata, responseBody, message);
+    case INTERNAL_SERVER_ERROR_STATUS:
+      return new InternalServerErrorError(
+        responseMetadata,
+        responseBody,
+        message,
+      );
+    case METHOD_NOT_ALLOWED_STATUS:
+      return new MethodNotAllowedError(responseMetadata, responseBody, message);
+    case NOT_ACCEPTABLE_STATUS:
+      return new NotAcceptableError(responseMetadata, responseBody, message);
+    case NOT_FOUND_STATUS:
+      return new NotFoundError(responseMetadata, responseBody, message);
+    case PRECONDITION_FAILED_STATUS:
+      return new PreconditionFailedError(
+        responseMetadata,
+        responseBody,
+        message,
+      );
+    case TOO_MANY_REQUESTS_STATUS:
+      return new TooManyRequestsError(responseMetadata, responseBody, message);
+    case UNAUTHORIZED_STATUS:
+      return new UnauthorizedError(responseMetadata, responseBody, message);
+    case UNSUPPORTED_MEDIA_TYPE_STATUS:
+      return new UnsupportedMediaTypeError(
+        responseMetadata,
+        responseBody,
+        message,
+      );
+    default:
+      return new ClientHttpError(responseMetadata, responseBody, message);
+  }
+}
+
+export default handleErrorResponse;

--- a/src/http/httpError.mock.ts
+++ b/src/http/httpError.mock.ts
@@ -1,0 +1,48 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { PROBLEM_DETAILS_MIME } from "./problemDetails";
+
+export const mockResponse = ({
+  body,
+  status,
+  statusText,
+  headers,
+}: {
+  body?: string;
+  status?: number;
+  statusText?: string;
+  headers?: Headers;
+  responseUrl?: string;
+} = {}): Response => {
+  const response = new Response(body ?? undefined, {
+    status: status ?? 400,
+    statusText: statusText ?? "Bad Request",
+    headers:
+      headers ??
+      new Headers({
+        "Content-Type": PROBLEM_DETAILS_MIME,
+      }),
+  });
+  return response;
+};
+
+export default mockResponse;

--- a/src/http/httpError.test.ts
+++ b/src/http/httpError.test.ts
@@ -21,13 +21,10 @@
 import { describe, it, expect, jest } from "@jest/globals";
 import { ClientHttpError } from "./httpError";
 import { mockProblemDetails } from "./problemDetails.mock";
-import {
-  DEFAULT_TYPE,
-  PROBLEM_DETAILS_MIME,
-  hasProblemDetails,
-} from "./problemDetails";
+import { DEFAULT_TYPE, hasProblemDetails } from "./problemDetails";
 import InruptClientError from "../clientError";
 import { hasErrorResponse } from "./errorResponse";
+import mockResponseBase from "./httpError.mock";
 
 const mockResponse = ({
   body,
@@ -42,15 +39,7 @@ const mockResponse = ({
   headers?: Headers;
   responseUrl?: string;
 } = {}): Response => {
-  const response = new Response(body ?? undefined, {
-    status: status ?? 400,
-    statusText: statusText ?? "Bad Request",
-    headers:
-      headers ??
-      new Headers({
-        "Content-Type": PROBLEM_DETAILS_MIME,
-      }),
-  });
+  const response = mockResponseBase({ body, status, statusText, headers });
   jest
     .spyOn(response, "url", "get")
     .mockReturnValue(responseUrl ?? "https://example.org/resource");

--- a/src/http/wellKnown/badRequestError.test.ts
+++ b/src/http/wellKnown/badRequestError.test.ts
@@ -23,7 +23,7 @@ import { BadRequestError, BAD_REQUEST_STATUS } from "./badRequestError";
 import { mockResponse } from "./wellKnown.mock";
 
 describe("BadRequestError", () => {
-  it("builds an Error object when provided an response with status 400", () => {
+  it("builds an Error object when provided a response with status 400", () => {
     const response = mockResponse({ status: BAD_REQUEST_STATUS });
     const e = new BadRequestError(
       response,

--- a/src/http/wellKnown/badRequestError.test.ts
+++ b/src/http/wellKnown/badRequestError.test.ts
@@ -33,7 +33,7 @@ describe("BadRequestError", () => {
     expect(e.response.status).toBe(BAD_REQUEST_STATUS);
   });
 
-  it("throws when provided a status code not equal to 400", () => {
+  it("throws when provided a status code not equal to", () => {
     const response = mockResponse({ status: 499 });
     expect(() => {
       // The object is built to check an error is thrown.

--- a/src/http/wellKnown/badRequestError.test.ts
+++ b/src/http/wellKnown/badRequestError.test.ts
@@ -1,0 +1,44 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { BadRequestError, BAD_REQUEST_STATUS } from "./badRequestError";
+import { mockResponse } from "./wellKnown.mock";
+
+describe("BadRequestError", () => {
+  it("builds an Error object when provided an response with status 400", () => {
+    const response = mockResponse({ status: BAD_REQUEST_STATUS });
+    const e = new BadRequestError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(BAD_REQUEST_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 400", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new BadRequestError(response, "Some response body", "Some error message");
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/badRequestError.ts
+++ b/src/http/wellKnown/badRequestError.ts
@@ -24,16 +24,15 @@ import { ClientHttpError } from "../httpError";
 
 export const BAD_REQUEST_STATUS = 400 as const;
 
-export type BadRequestErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof BAD_REQUEST_STATUS;
-  }
->;
+export type BadRequestErrorResponse = ErrorResponse & {
+  status: typeof BAD_REQUEST_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Bad Request (400) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.400 | RFC 9110 (15.5.1.) 400 Bad Request}
+ * @since unreleased
  */
 export class BadRequestError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/badRequestError.ts
+++ b/src/http/wellKnown/badRequestError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const BAD_REQUEST_STATUS = 400 as const;
+
+export type BadRequestErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof BAD_REQUEST_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Bad Request (400) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.400 | RFC 9110 (15.5.1.) 400 Bad Request}
+ */
+export class BadRequestError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== BAD_REQUEST_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building BadRequestError: expected ${BAD_REQUEST_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): BadRequestErrorResponse {
+    return super.response as BadRequestErrorResponse;
+  }
+}
+
+export default BadRequestError;

--- a/src/http/wellKnown/conflictError.test.ts
+++ b/src/http/wellKnown/conflictError.test.ts
@@ -1,0 +1,44 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import { ConflictError, CONFLICT_STATUS } from "./conflictError";
+
+describe("ConflictError", () => {
+  it("builds an Error object when provided an response with status 409", () => {
+    const response = mockResponse({ status: CONFLICT_STATUS });
+    const e = new ConflictError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(CONFLICT_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 409", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new ConflictError(response, "Some response body", "Some error message");
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/conflictError.ts
+++ b/src/http/wellKnown/conflictError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const CONFLICT_STATUS = 409 as const;
 
-export type ConflictErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof CONFLICT_STATUS;
-  }
->;
+export type ConflictErrorResponse = ErrorResponse & {
+  status: typeof CONFLICT_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Conflict (409) response.

--- a/src/http/wellKnown/conflictError.ts
+++ b/src/http/wellKnown/conflictError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const CONFLICT_STATUS = 409 as const;
+
+export type ConflictErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof CONFLICT_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Conflict (409) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.409 | RFC 9110 (15.5.10.) 409 Conflict}
+ */
+export class ConflictError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== CONFLICT_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building ConflictError: expected ${CONFLICT_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): ConflictErrorResponse {
+    return super.response as ConflictErrorResponse;
+  }
+}
+
+export default ConflictError;

--- a/src/http/wellKnown/conflictError.ts
+++ b/src/http/wellKnown/conflictError.ts
@@ -34,6 +34,7 @@ export type ConflictErrorResponse = Readonly<
  * Runtime error thrown on HTTP Conflict (409) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.409 | RFC 9110 (15.5.10.) 409 Conflict}
+ * @since unreleased
  */
 export class ConflictError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/forbiddenError.test.ts
+++ b/src/http/wellKnown/forbiddenError.test.ts
@@ -1,0 +1,44 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import { ForbiddenError, FORBIDDEN_STATUS } from "./forbiddenError";
+
+describe("ForbiddenError", () => {
+  it("builds an Error object when provided an response with status 403", () => {
+    const response = mockResponse({ status: FORBIDDEN_STATUS });
+    const e = new ForbiddenError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(FORBIDDEN_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 403", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new ForbiddenError(response, "Some response body", "Some error message");
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/forbiddenError.ts
+++ b/src/http/wellKnown/forbiddenError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const FORBIDDEN_STATUS = 403 as const;
 
-export type ForbiddenErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof FORBIDDEN_STATUS;
-  }
->;
+export type ForbiddenErrorResponse = ErrorResponse & {
+  status: typeof FORBIDDEN_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Forbidden (403) response.

--- a/src/http/wellKnown/forbiddenError.ts
+++ b/src/http/wellKnown/forbiddenError.ts
@@ -34,6 +34,7 @@ export type ForbiddenErrorResponse = Readonly<
  * Runtime error thrown on HTTP Forbidden (403) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.403 | RFC 9110 (15.5.4.) 403 Forbidden}
+ * @since unreleased
  */
 export class ForbiddenError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/forbiddenError.ts
+++ b/src/http/wellKnown/forbiddenError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const FORBIDDEN_STATUS = 403 as const;
+
+export type ForbiddenErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof FORBIDDEN_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Forbidden (403) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.403 | RFC 9110 (15.5.4.) 403 Forbidden}
+ */
+export class ForbiddenError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== FORBIDDEN_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building ForbiddenError: expected ${FORBIDDEN_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): ForbiddenErrorResponse {
+    return super.response as ForbiddenErrorResponse;
+  }
+}
+
+export default ForbiddenError;

--- a/src/http/wellKnown/goneError.test.ts
+++ b/src/http/wellKnown/goneError.test.ts
@@ -1,0 +1,44 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import { GoneError, GONE_STATUS } from "./goneError";
+
+describe("GoneError", () => {
+  it("builds an Error object when provided an response with status 410", () => {
+    const response = mockResponse({ status: GONE_STATUS });
+    const e = new GoneError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(GONE_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 410", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new GoneError(response, "Some response body", "Some error message");
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/goneError.ts
+++ b/src/http/wellKnown/goneError.ts
@@ -34,6 +34,7 @@ export type GoneErrorResponse = Readonly<
  * Runtime error thrown on HTTP Gone (410) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.410 | RFC 9110 (15.5.11.) 410 Gone}
+ * @since unreleased
  */
 export class GoneError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/goneError.ts
+++ b/src/http/wellKnown/goneError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const GONE_STATUS = 410 as const;
 
-export type GoneErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof GONE_STATUS;
-  }
->;
+export type GoneErrorResponse = ErrorResponse & {
+  status: typeof GONE_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Gone (410) response.

--- a/src/http/wellKnown/goneError.ts
+++ b/src/http/wellKnown/goneError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const GONE_STATUS = 410 as const;
+
+export type GoneErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof GONE_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Gone (410) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.410 | RFC 9110 (15.5.11.) 410 Gone}
+ */
+export class GoneError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== GONE_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building GoneError: expected ${GONE_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): GoneErrorResponse {
+    return super.response as GoneErrorResponse;
+  }
+}
+
+export default GoneError;

--- a/src/http/wellKnown/internalServerError.test.ts
+++ b/src/http/wellKnown/internalServerError.test.ts
@@ -21,14 +21,14 @@
 import { describe, it, expect } from "@jest/globals";
 import { mockResponse } from "./wellKnown.mock";
 import {
-  InternalServerErrorError,
+  InternalServerError,
   INTERNAL_SERVER_ERROR_STATUS,
-} from "./internalServerErrorError";
+} from "./internalServerError";
 
-describe("InternalServerErrorError", () => {
+describe("InternalServerError", () => {
   it("builds an Error object when provided an response with status 500", () => {
     const response = mockResponse({ status: INTERNAL_SERVER_ERROR_STATUS });
-    const e = new InternalServerErrorError(
+    const e = new InternalServerError(
       response,
       "Some response body",
       "Some error message",
@@ -41,7 +41,7 @@ describe("InternalServerErrorError", () => {
     expect(() => {
       // The object is built to check an error is thrown.
       // eslint-disable-next-line no-new
-      new InternalServerErrorError(
+      new InternalServerError(
         response,
         "Some response body",
         "Some error message",

--- a/src/http/wellKnown/internalServerError.ts
+++ b/src/http/wellKnown/internalServerError.ts
@@ -24,7 +24,7 @@ import { ClientHttpError } from "../httpError";
 
 export const INTERNAL_SERVER_ERROR_STATUS = 500 as const;
 
-export type InternalServerErrorErrorResponse = ErrorResponse & {
+export type InternalServerErrorResponse = ErrorResponse & {
   status: typeof INTERNAL_SERVER_ERROR_STATUS;
 };
 
@@ -34,7 +34,7 @@ export type InternalServerErrorErrorResponse = ErrorResponse & {
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.500 | RFC 9110 (15.6.1.) 500 Internal Server Error}
  * @since unreleased
  */
-export class InternalServerErrorError extends ClientHttpError {
+export class InternalServerError extends ClientHttpError {
   constructor(
     responseMetadata: {
       status: number;
@@ -49,14 +49,14 @@ export class InternalServerErrorError extends ClientHttpError {
     super(responseMetadata, responseBody, message, options);
     if (responseMetadata.status !== INTERNAL_SERVER_ERROR_STATUS) {
       throw new InruptClientError(
-        `Unexpected status found building InternalServerErrorError: expected ${INTERNAL_SERVER_ERROR_STATUS}, found ${responseMetadata.status}`,
+        `Unexpected status found building InternalServerError: expected ${INTERNAL_SERVER_ERROR_STATUS}, found ${responseMetadata.status}`,
       );
     }
   }
 
-  get response(): InternalServerErrorErrorResponse {
-    return super.response as InternalServerErrorErrorResponse;
+  get response(): InternalServerErrorResponse {
+    return super.response as InternalServerErrorResponse;
   }
 }
 
-export default InternalServerErrorError;
+export default InternalServerError;

--- a/src/http/wellKnown/internalServerErrorError.test.ts
+++ b/src/http/wellKnown/internalServerErrorError.test.ts
@@ -1,0 +1,47 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import {
+  InternalServerErrorError,
+  INTERNAL_SERVER_ERROR_STATUS,
+} from "./internalServerErrorError";
+
+describe("InternalServerErrorError", () => {
+  it("builds an Error object when provided an response with status 500", () => {
+    const response = mockResponse({ status: INTERNAL_SERVER_ERROR_STATUS });
+    const e = new InternalServerErrorError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(INTERNAL_SERVER_ERROR_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 500", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new InternalServerErrorError(response, "Some response body", "Some error message");
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/internalServerErrorError.test.ts
+++ b/src/http/wellKnown/internalServerErrorError.test.ts
@@ -41,7 +41,11 @@ describe("InternalServerErrorError", () => {
     expect(() => {
       // The object is built to check an error is thrown.
       // eslint-disable-next-line no-new
-      new InternalServerErrorError(response, "Some response body", "Some error message");
+      new InternalServerErrorError(
+        response,
+        "Some response body",
+        "Some error message",
+      );
     }).toThrow();
   });
 });

--- a/src/http/wellKnown/internalServerErrorError.ts
+++ b/src/http/wellKnown/internalServerErrorError.ts
@@ -34,6 +34,7 @@ export type InternalServerErrorErrorResponse = Readonly<
  * Runtime error thrown on HTTP Conflict (500) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.500 | RFC 9110 (15.6.1.) 500 Internal Server Error}
+ * @since unreleased
  */
 export class InternalServerErrorError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/internalServerErrorError.ts
+++ b/src/http/wellKnown/internalServerErrorError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const INTERNAL_SERVER_ERROR_STATUS = 410 as const;
+
+export type InternalServerErrorErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof INTERNAL_SERVER_ERROR_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Conflict (500) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.500 | RFC 9110 (15.6.1.) 500 Internal Server Error}
+ */
+export class InternalServerErrorError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== INTERNAL_SERVER_ERROR_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building InternalServerErrorError: expected ${INTERNAL_SERVER_ERROR_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): InternalServerErrorErrorResponse {
+    return super.response as InternalServerErrorErrorResponse;
+  }
+}
+
+export default InternalServerErrorError;

--- a/src/http/wellKnown/internalServerErrorError.ts
+++ b/src/http/wellKnown/internalServerErrorError.ts
@@ -22,7 +22,7 @@ import { InruptClientError } from "../../clientError";
 import type { ErrorResponse } from "../errorResponse";
 import { ClientHttpError } from "../httpError";
 
-export const INTERNAL_SERVER_ERROR_STATUS = 410 as const;
+export const INTERNAL_SERVER_ERROR_STATUS = 500 as const;
 
 export type InternalServerErrorErrorResponse = ErrorResponse & {
   status: typeof INTERNAL_SERVER_ERROR_STATUS;

--- a/src/http/wellKnown/internalServerErrorError.ts
+++ b/src/http/wellKnown/internalServerErrorError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const INTERNAL_SERVER_ERROR_STATUS = 410 as const;
 
-export type InternalServerErrorErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof INTERNAL_SERVER_ERROR_STATUS;
-  }
->;
+export type InternalServerErrorErrorResponse = ErrorResponse & {
+  status: typeof INTERNAL_SERVER_ERROR_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Conflict (500) response.

--- a/src/http/wellKnown/methodNotAllowedError.test.ts
+++ b/src/http/wellKnown/methodNotAllowedError.test.ts
@@ -1,0 +1,51 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import {
+  MethodNotAllowedError,
+  METHOD_NOT_ALLOWED_STATUS,
+} from "./methodNotAllowedError";
+
+describe("MethodNotAllowedError", () => {
+  it("builds an Error object when provided an response with status 405", () => {
+    const response = mockResponse({ status: METHOD_NOT_ALLOWED_STATUS });
+    const e = new MethodNotAllowedError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(METHOD_NOT_ALLOWED_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 405", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new MethodNotAllowedError(
+        response,
+        "Some response body",
+        "Some error message",
+      );
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/methodNotAllowedError.ts
+++ b/src/http/wellKnown/methodNotAllowedError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const METHOD_NOT_ALLOWED_STATUS = 405 as const;
+
+export type MethodNotAllowedErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof METHOD_NOT_ALLOWED_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Method Not Allowed (405) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.405 | RFC 9110 (15.5.6.) 405 Method Not Allowed}
+ */
+export class MethodNotAllowedError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== METHOD_NOT_ALLOWED_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building MethodNotAllowedError: expected ${METHOD_NOT_ALLOWED_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): MethodNotAllowedErrorResponse {
+    return super.response as MethodNotAllowedErrorResponse;
+  }
+}
+
+export default MethodNotAllowedError;

--- a/src/http/wellKnown/methodNotAllowedError.ts
+++ b/src/http/wellKnown/methodNotAllowedError.ts
@@ -34,6 +34,7 @@ export type MethodNotAllowedErrorResponse = Readonly<
  * Runtime error thrown on HTTP Method Not Allowed (405) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.405 | RFC 9110 (15.5.6.) 405 Method Not Allowed}
+ * @since unreleased
  */
 export class MethodNotAllowedError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/methodNotAllowedError.ts
+++ b/src/http/wellKnown/methodNotAllowedError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const METHOD_NOT_ALLOWED_STATUS = 405 as const;
 
-export type MethodNotAllowedErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof METHOD_NOT_ALLOWED_STATUS;
-  }
->;
+export type MethodNotAllowedErrorResponse = ErrorResponse & {
+  status: typeof METHOD_NOT_ALLOWED_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Method Not Allowed (405) response.

--- a/src/http/wellKnown/notAcceptableError.test.ts
+++ b/src/http/wellKnown/notAcceptableError.test.ts
@@ -1,0 +1,51 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import {
+  NotAcceptableError,
+  NOT_ACCEPTABLE_STATUS,
+} from "./notAcceptableError";
+
+describe("NotAcceptableError", () => {
+  it("builds an Error object when provided an response with status 406", () => {
+    const response = mockResponse({ status: NOT_ACCEPTABLE_STATUS });
+    const e = new NotAcceptableError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(NOT_ACCEPTABLE_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 406", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new NotAcceptableError(
+        response,
+        "Some response body",
+        "Some error message",
+      );
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/notAcceptableError.ts
+++ b/src/http/wellKnown/notAcceptableError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const NOT_ACCEPTABLE_STATUS = 406 as const;
+
+export type NotAcceptableErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof NOT_ACCEPTABLE_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Not Acceptable (406) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.406 | RFC 9110 (15.5.7.) 406 Not Acceptable}
+ */
+export class NotAcceptableError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== NOT_ACCEPTABLE_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building NotAcceptableError: expected ${NOT_ACCEPTABLE_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): NotAcceptableErrorResponse {
+    return super.response as NotAcceptableErrorResponse;
+  }
+}
+
+export default NotAcceptableError;

--- a/src/http/wellKnown/notAcceptableError.ts
+++ b/src/http/wellKnown/notAcceptableError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const NOT_ACCEPTABLE_STATUS = 406 as const;
 
-export type NotAcceptableErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof NOT_ACCEPTABLE_STATUS;
-  }
->;
+export type NotAcceptableErrorResponse = ErrorResponse & {
+  status: typeof NOT_ACCEPTABLE_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Not Acceptable (406) response.

--- a/src/http/wellKnown/notAcceptableError.ts
+++ b/src/http/wellKnown/notAcceptableError.ts
@@ -34,6 +34,7 @@ export type NotAcceptableErrorResponse = Readonly<
  * Runtime error thrown on HTTP Not Acceptable (406) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.406 | RFC 9110 (15.5.7.) 406 Not Acceptable}
+ * @since unreleased
  */
 export class NotAcceptableError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/notFoundError.test.ts
+++ b/src/http/wellKnown/notFoundError.test.ts
@@ -1,0 +1,44 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import { NotFoundError, NOT_FOUND_STATUS } from "./notFoundError";
+
+describe("NotFoundError", () => {
+  it("builds an Error object when provided an response with status 404", () => {
+    const response = mockResponse({ status: NOT_FOUND_STATUS });
+    const e = new NotFoundError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(NOT_FOUND_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 404", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new NotFoundError(response, "Some response body", "Some error message");
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/notFoundError.ts
+++ b/src/http/wellKnown/notFoundError.ts
@@ -34,6 +34,7 @@ export type NotFoundErrorResponse = Readonly<
  * Runtime error thrown on HTTP Not Found (404) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.404 | RFC 9110 (15.5.5.) 404 Not Found}
+ * @since unreleased
  */
 export class NotFoundError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/notFoundError.ts
+++ b/src/http/wellKnown/notFoundError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const NOT_FOUND_STATUS = 404 as const;
 
-export type NotFoundErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof NOT_FOUND_STATUS;
-  }
->;
+export type NotFoundErrorResponse = ErrorResponse & {
+  status: typeof NOT_FOUND_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Not Found (404) response.

--- a/src/http/wellKnown/notFoundError.ts
+++ b/src/http/wellKnown/notFoundError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const NOT_FOUND_STATUS = 404 as const;
+
+export type NotFoundErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof NOT_FOUND_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Not Found (404) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.404 | RFC 9110 (15.5.5.) 404 Not Found}
+ */
+export class NotFoundError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== NOT_FOUND_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building NotFoundError: expected ${NOT_FOUND_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): NotFoundErrorResponse {
+    return super.response as NotFoundErrorResponse;
+  }
+}
+
+export default NotFoundError;

--- a/src/http/wellKnown/preconditionFailedError.test.ts
+++ b/src/http/wellKnown/preconditionFailedError.test.ts
@@ -1,0 +1,51 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import {
+  PreconditionFailedError,
+  PRECONDITION_FAILED_STATUS,
+} from "./preconditionFailedError";
+
+describe("PreconditionFailedError", () => {
+  it("builds an Error object when provided an response with status 412", () => {
+    const response = mockResponse({ status: PRECONDITION_FAILED_STATUS });
+    const e = new PreconditionFailedError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(PRECONDITION_FAILED_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 412", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new PreconditionFailedError(
+        response,
+        "Some response body",
+        "Some error message",
+      );
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/preconditionFailedError.ts
+++ b/src/http/wellKnown/preconditionFailedError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const PRECONDITION_FAILED_STATUS = 412 as const;
+
+export type PreconditionFailedErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof PRECONDITION_FAILED_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Precondition Failed (412) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.412 | RFC 9110 (15.5.13.) 412 Precondition Failed}
+ */
+export class PreconditionFailedError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== PRECONDITION_FAILED_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building PreconditionFailedError: expected ${PRECONDITION_FAILED_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): PreconditionFailedErrorResponse {
+    return super.response as PreconditionFailedErrorResponse;
+  }
+}
+
+export default PreconditionFailedError;

--- a/src/http/wellKnown/preconditionFailedError.ts
+++ b/src/http/wellKnown/preconditionFailedError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const PRECONDITION_FAILED_STATUS = 412 as const;
 
-export type PreconditionFailedErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof PRECONDITION_FAILED_STATUS;
-  }
->;
+export type PreconditionFailedErrorResponse = ErrorResponse & {
+  status: typeof PRECONDITION_FAILED_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Precondition Failed (412) response.

--- a/src/http/wellKnown/preconditionFailedError.ts
+++ b/src/http/wellKnown/preconditionFailedError.ts
@@ -34,6 +34,7 @@ export type PreconditionFailedErrorResponse = Readonly<
  * Runtime error thrown on HTTP Precondition Failed (412) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.412 | RFC 9110 (15.5.13.) 412 Precondition Failed}
+ * @since unreleased
  */
 export class PreconditionFailedError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/tooManyRequestsError.test.ts
+++ b/src/http/wellKnown/tooManyRequestsError.test.ts
@@ -1,0 +1,51 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import {
+  TooManyRequestsError,
+  TOO_MANY_REQUESTS_STATUS,
+} from "./tooManyRequestsError";
+
+describe("TooManyRequestsError", () => {
+  it("builds an Error object when provided an response with status 429", () => {
+    const response = mockResponse({ status: TOO_MANY_REQUESTS_STATUS });
+    const e = new TooManyRequestsError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(TOO_MANY_REQUESTS_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 429", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new TooManyRequestsError(
+        response,
+        "Some response body",
+        "Some error message",
+      );
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/tooManyRequestsError.ts
+++ b/src/http/wellKnown/tooManyRequestsError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const TOO_MANY_REQUESTS_STATUS = 429 as const;
+
+export type TooManyRequestsErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof TOO_MANY_REQUESTS_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Too Many Requests (429) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc6585#section-4 | RFC 6585 (4.) 429 Too Many Requests}
+ */
+export class TooManyRequestsError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== TOO_MANY_REQUESTS_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building TooManyRequestsError: expected ${TOO_MANY_REQUESTS_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): TooManyRequestsErrorResponse {
+    return super.response as TooManyRequestsErrorResponse;
+  }
+}
+
+export default TooManyRequestsError;

--- a/src/http/wellKnown/tooManyRequestsError.ts
+++ b/src/http/wellKnown/tooManyRequestsError.ts
@@ -34,6 +34,7 @@ export type TooManyRequestsErrorResponse = Readonly<
  * Runtime error thrown on HTTP Too Many Requests (429) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc6585#section-4 | RFC 6585 (4.) 429 Too Many Requests}
+ * @since unreleased
  */
 export class TooManyRequestsError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/tooManyRequestsError.ts
+++ b/src/http/wellKnown/tooManyRequestsError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const TOO_MANY_REQUESTS_STATUS = 429 as const;
 
-export type TooManyRequestsErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof TOO_MANY_REQUESTS_STATUS;
-  }
->;
+export type TooManyRequestsErrorResponse = ErrorResponse & {
+  status: typeof TOO_MANY_REQUESTS_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Too Many Requests (429) response.

--- a/src/http/wellKnown/unauthorizedError.test.ts
+++ b/src/http/wellKnown/unauthorizedError.test.ts
@@ -1,0 +1,48 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import { UnauthorizedError, UNAUTHORIZED_STATUS } from "./unauthorizedError";
+
+describe("UnauthorizedError", () => {
+  it("builds an Error object when provided an response with status 401", () => {
+    const response = mockResponse({ status: UNAUTHORIZED_STATUS });
+    const e = new UnauthorizedError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(UNAUTHORIZED_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 401", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new UnauthorizedError(
+        response,
+        "Some response body",
+        "Some error message",
+      );
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/unauthorizedError.ts
+++ b/src/http/wellKnown/unauthorizedError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const UNAUTHORIZED_STATUS = 412 as const;
 
-export type UnauthorizedErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof UNAUTHORIZED_STATUS;
-  }
->;
+export type UnauthorizedErrorResponse = ErrorResponse & {
+  status: typeof UNAUTHORIZED_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Unauthorized (401) response.

--- a/src/http/wellKnown/unauthorizedError.ts
+++ b/src/http/wellKnown/unauthorizedError.ts
@@ -34,6 +34,7 @@ export type UnauthorizedErrorResponse = Readonly<
  * Runtime error thrown on HTTP Unauthorized (401) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.401 | RFC 9110 (15.5.2.) 401 Unauthorized}
+ * @since unreleased
  */
 export class UnauthorizedError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/unauthorizedError.ts
+++ b/src/http/wellKnown/unauthorizedError.ts
@@ -22,7 +22,7 @@ import { InruptClientError } from "../../clientError";
 import type { ErrorResponse } from "../errorResponse";
 import { ClientHttpError } from "../httpError";
 
-export const UNAUTHORIZED_STATUS = 412 as const;
+export const UNAUTHORIZED_STATUS = 401 as const;
 
 export type UnauthorizedErrorResponse = ErrorResponse & {
   status: typeof UNAUTHORIZED_STATUS;

--- a/src/http/wellKnown/unauthorizedError.ts
+++ b/src/http/wellKnown/unauthorizedError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const UNAUTHORIZED_STATUS = 412 as const;
+
+export type UnauthorizedErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof UNAUTHORIZED_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Unauthorized (401) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.401 | RFC 9110 (15.5.2.) 401 Unauthorized}
+ */
+export class UnauthorizedError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== UNAUTHORIZED_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building UnauthorizedError: expected ${UNAUTHORIZED_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): UnauthorizedErrorResponse {
+    return super.response as UnauthorizedErrorResponse;
+  }
+}
+
+export default UnauthorizedError;

--- a/src/http/wellKnown/unsupportedMediaTypeError.test.ts
+++ b/src/http/wellKnown/unsupportedMediaTypeError.test.ts
@@ -1,0 +1,51 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { describe, it, expect } from "@jest/globals";
+import { mockResponse } from "./wellKnown.mock";
+import {
+  UnsupportedMediaTypeError,
+  UNSUPPORTED_MEDIA_TYPE_STATUS,
+} from "./unsupportedMediaTypeError";
+
+describe("UnsupportedMediaTypeError", () => {
+  it("builds an Error object when provided an response with status 415", () => {
+    const response = mockResponse({ status: UNSUPPORTED_MEDIA_TYPE_STATUS });
+    const e = new UnsupportedMediaTypeError(
+      response,
+      "Some response body",
+      "Some error message",
+    );
+    expect(e.response.status).toBe(UNSUPPORTED_MEDIA_TYPE_STATUS);
+  });
+
+  it("throws when provided a status code not equal to 415", () => {
+    const response = mockResponse({ status: 499 });
+    expect(() => {
+      // The object is built to check an error is thrown.
+      // eslint-disable-next-line no-new
+      new UnsupportedMediaTypeError(
+        response,
+        "Some response body",
+        "Some error message",
+      );
+    }).toThrow();
+  });
+});

--- a/src/http/wellKnown/unsupportedMediaTypeError.ts
+++ b/src/http/wellKnown/unsupportedMediaTypeError.ts
@@ -34,6 +34,7 @@ export type UnsupportedMediaTypeErrorResponse = Readonly<
  * Runtime error thrown on HTTP Unsupported Media Type (415) response.
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.415 | RFC 9110 (15.5.16.) 415 Unsupported Media Type}
+ * @since unreleased
  */
 export class UnsupportedMediaTypeError extends ClientHttpError {
   constructor(

--- a/src/http/wellKnown/unsupportedMediaTypeError.ts
+++ b/src/http/wellKnown/unsupportedMediaTypeError.ts
@@ -1,0 +1,63 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import { InruptClientError } from "../../clientError";
+import type { ErrorResponse } from "../errorResponse";
+import { ClientHttpError } from "../httpError";
+
+export const UNSUPPORTED_MEDIA_TYPE_STATUS = 415 as const;
+
+export type UnsupportedMediaTypeErrorResponse = Readonly<
+  ErrorResponse & {
+    status: typeof UNSUPPORTED_MEDIA_TYPE_STATUS;
+  }
+>;
+
+/**
+ * Runtime error thrown on HTTP Unsupported Media Type (415) response.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110#status.415 | RFC 9110 (15.5.16.) 415 Unsupported Media Type}
+ */
+export class UnsupportedMediaTypeError extends ClientHttpError {
+  constructor(
+    responseMetadata: {
+      status: number;
+      statusText: string;
+      headers: Headers;
+      url: string;
+    },
+    responseBody: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(responseMetadata, responseBody, message, options);
+    if (responseMetadata.status !== UNSUPPORTED_MEDIA_TYPE_STATUS) {
+      throw new InruptClientError(
+        `Unexpected status found building UnsupportedMediaTypeError: expected ${UNSUPPORTED_MEDIA_TYPE_STATUS}, found ${responseMetadata.status}`,
+      );
+    }
+  }
+
+  get response(): UnsupportedMediaTypeErrorResponse {
+    return super.response as UnsupportedMediaTypeErrorResponse;
+  }
+}
+
+export default UnsupportedMediaTypeError;

--- a/src/http/wellKnown/unsupportedMediaTypeError.ts
+++ b/src/http/wellKnown/unsupportedMediaTypeError.ts
@@ -24,11 +24,9 @@ import { ClientHttpError } from "../httpError";
 
 export const UNSUPPORTED_MEDIA_TYPE_STATUS = 415 as const;
 
-export type UnsupportedMediaTypeErrorResponse = Readonly<
-  ErrorResponse & {
-    status: typeof UNSUPPORTED_MEDIA_TYPE_STATUS;
-  }
->;
+export type UnsupportedMediaTypeErrorResponse = ErrorResponse & {
+  status: typeof UNSUPPORTED_MEDIA_TYPE_STATUS;
+};
 
 /**
  * Runtime error thrown on HTTP Unsupported Media Type (415) response.

--- a/src/http/wellKnown/wellKnown.mock.ts
+++ b/src/http/wellKnown/wellKnown.mock.ts
@@ -1,0 +1,33 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { PROBLEM_DETAILS_MIME } from "../problemDetails";
+
+export function mockResponse({ status }: { status: number }): Response {
+  return new Response(undefined, {
+    status,
+    headers: new Headers({
+      "Content-Type": PROBLEM_DETAILS_MIME,
+    }),
+  });
+}
+
+export default mockResponse;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,10 +56,10 @@ export {
   type GoneErrorResponse,
 } from "./http/wellKnown/goneError";
 export {
-  InternalServerErrorError,
+  InternalServerError,
   INTERNAL_SERVER_ERROR_STATUS,
-  type InternalServerErrorErrorResponse,
-} from "./http/wellKnown/internalServerErrorError";
+  type InternalServerErrorResponse,
+} from "./http/wellKnown/internalServerError";
 export {
   MethodNotAllowedError,
   METHOD_NOT_ALLOWED_STATUS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@
 //
 
 export { InruptClientError } from "./clientError";
-export { ClientHttpError } from "./http/httpError";
+export { ClientHttpError, handleErrorResponse } from "./http/httpError";
 export {
   DEFAULT_TYPE,
   PROBLEM_DETAILS_MIME,

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,3 +34,63 @@ export {
   type WithErrorResponse,
   hasErrorResponse,
 } from "./http/errorResponse";
+export {
+  BadRequestError,
+  BAD_REQUEST_STATUS,
+  type BadRequestErrorResponse,
+} from "./http/wellKnown/badRequestError";
+export {
+  ConflictError,
+  CONFLICT_STATUS,
+  type ConflictErrorResponse,
+} from "./http/wellKnown/conflictError";
+export {
+  ForbiddenError,
+  FORBIDDEN_STATUS,
+  type ForbiddenErrorResponse,
+} from "./http/wellKnown/forbiddenError";
+export {
+  GoneError,
+  GONE_STATUS,
+  type GoneErrorResponse,
+} from "./http/wellKnown/goneError";
+export {
+  InternalServerErrorError,
+  INTERNAL_SERVER_ERROR_STATUS,
+  type InternalServerErrorErrorResponse,
+} from "./http/wellKnown/internalServerErrorError";
+export {
+  MethodNotAllowedError,
+  METHOD_NOT_ALLOWED_STATUS,
+  type MethodNotAllowedErrorResponse,
+} from "./http/wellKnown/methodNotAllowedError";
+export {
+  NotAcceptableError,
+  NOT_ACCEPTABLE_STATUS,
+  type NotAcceptableErrorResponse,
+} from "./http/wellKnown/notAcceptableError";
+export {
+  NotFoundError,
+  NOT_FOUND_STATUS,
+  type NotFoundErrorResponse,
+} from "./http/wellKnown/notFoundError";
+export {
+  PreconditionFailedError as PreconditionsFailedError,
+  PRECONDITION_FAILED_STATUS as PRECONDITIONS_FAILED_STATUS,
+  type PreconditionFailedErrorResponse as PreconditionsFailedErrorResponse,
+} from "./http/wellKnown/preconditionFailedError";
+export {
+  TooManyRequestsError,
+  TOO_MANY_REQUESTS_STATUS,
+  type TooManyRequestsErrorResponse,
+} from "./http/wellKnown/tooManyRequestsError";
+export {
+  UnauthorizedError,
+  UNAUTHORIZED_STATUS,
+  type UnauthorizedErrorResponse,
+} from "./http/wellKnown/unauthorizedError";
+export {
+  UnsupportedMediaTypeError,
+  UNSUPPORTED_MEDIA_TYPE_STATUS,
+  type UnsupportedMediaTypeErrorResponse,
+} from "./http/wellKnown/unsupportedMediaTypeError";

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,9 +75,9 @@ export {
   type NotFoundErrorResponse,
 } from "./http/wellKnown/notFoundError";
 export {
-  PreconditionFailedError as PreconditionsFailedError,
-  PRECONDITION_FAILED_STATUS as PRECONDITIONS_FAILED_STATUS,
-  type PreconditionFailedErrorResponse as PreconditionsFailedErrorResponse,
+  PreconditionFailedError,
+  PRECONDITION_FAILED_STATUS,
+  type PreconditionFailedErrorResponse,
 } from "./http/wellKnown/preconditionFailedError";
 export {
   TooManyRequestsError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@
 //
 
 export { InruptClientError } from "./clientError";
-export { ClientHttpError, handleErrorResponse } from "./http/httpError";
+export { ClientHttpError } from "./http/httpError";
+export { handleErrorResponse } from "./http/handleErrorResponse";
 export {
   DEFAULT_TYPE,
   PROBLEM_DETAILS_MIME,


### PR DESCRIPTION
This exports common error types for convenience, such as BadRequestError for HTTP responses with status 400, or NotFoundError for HTTP responses wih status 404.

Each class overrides the `response` getter to constrain the status code. The `problemDetails` getter is unchanged.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New elements of the public API have appropriate API docs (including `@since` and `@example`).
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).