### PR TITLE
Ignore major updates to eslint and typedoc-plugin-markdown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,8 @@ updates:
     open-pull-requests-limit: 10
     # The following is required for workspaces to be updated: see https://github.com/dependabot/dependabot-core/issues/5226.
     versioning-strategy: increase
-  - package-ecosystem: npm
-    directory: "/e2e/browser/test-app"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typedoc-plugin-markdown"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
The major version upgrades to the eslint and typedoc-plugin-markdown dependencies require some more significant refactors of the existing code. For now, these updates will be turned off to produce less dependabot noise.

Note: the `e2e/browser/test-app` is removed here because there is no such directory