### PR TITLE
Exclude test app transitive optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:e2e:node": "jest --selectProjects e2e-node --testTimeout 30000 --collectCoverage false",
     "test:e2e": "npm run test:e2e:node && npm run test:e2e:browser",
     "test:e2e:browser": "playwright test",
-    "test:e2e:browser:build": "cd e2e/browser/test-app && npm ci"
+    "test:e2e:browser:build": "cd e2e/browser/test-app && npm ci --omit=optional"
   },
   "homepage": "https://docs.inrupt.com/client-libraries/solid-client-errors-js/",
   "bugs": "https://github.com/inrupt/solid-client-errors-js/issues",


### PR DESCRIPTION
NextJS 15 brings in an optional dependency with a license incompatible with our policy, so this exclude optional dependencies when installing the test app.