### PR TITLE
Add license package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://docs.inrupt.com/client-libraries/solid-client-errors-js/",
   "bugs": "https://github.com/inrupt/solid-client-errors-js/issues",
+  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `@inrupt/solid-client-errors`
- updates only `package.json`

## Metadata added
- `license`: `MIT`

## Validation
- parsed `package.json` as JSON after the change
- confirmed the manifest still has `name: @inrupt/solid-client-errors`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package expose the project support/discovery information once the package is next released.