### PR TITLE
Setup staged publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,5 @@ jobs:
       # Ensure npm 11.5.1 or later for trusted publishing
       - run: npm install -g npm@latest
       - run: npm ci
-      - run: npm publish
+      - run: npm stage publish
+      - run: echo "The package has been staged, go to https://www.npmjs.com to publish it."

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://docs.inrupt.com/client-libraries/solid-client-errors-js/",
   "bugs": "https://github.com/inrupt/solid-client-errors-js/issues",
+  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Enforces an operator intervention (gated by 2FA) to publish the package after the automated CI staged it.