### PR TITLE
Update lockfile for e2e test directory

### DIFF
--- a/e2e/browser/test-app/package-lock.json
+++ b/e2e/browser/test-app/package-lock.json
@@ -51,48 +51,6 @@
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
-    "../../../../typescript-sdk-tools/packages/eslint-config": {
-      "name": "@inrupt/eslint-config-base",
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "^9.38.0",
-        "@eslint/json": "^0.13.2",
-        "@eslint/markdown": "^7.5.0",
-        "eslint": "^9.28.0",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-header": "^3.1.1",
-        "eslint-plugin-headers": "^1.3.3",
-        "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-jest": "^29.0.1",
-        "eslint-plugin-playwright": "^2.2.2",
-        "eslint-plugin-prettier": "^5.5.4",
-        "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^7.0.1",
-        "globals": "^16.4.0",
-        "jest": ">=30.2.0",
-        "prettier": ">=3.6.2",
-        "typescript-eslint": "^8.46.2"
-      },
-      "peerDependencies": {
-        "@rushstack/eslint-patch": ">=1.1.4",
-        "jest": ">=30.2.0",
-        "prettier": ">=3.6.2"
-      }
-    },
-    "../../../../typescript-sdk-tools/packages/eslint-config/node_modules/globals": {
-      "version": "16.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "../../../node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "dev": true,
@@ -101,24 +59,29 @@
         "node": ">=0.10.0"
       }
     },
-    "../../../node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "../../../node_modules/@babel/code-frame": {
-      "version": "7.27.1",
+    "../../../node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "../../../node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../../node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -127,7 +90,7 @@
       }
     },
     "../../../node_modules/@babel/compat-data": {
-      "version": "7.24.4",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -135,20 +98,20 @@
       }
     },
     "../../../node_modules/@babel/core": {
-      "version": "7.24.4",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.4",
-        "@babel/helper-compilation-targets": "^7.23.6",
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.24.4",
-        "@babel/parser": "^7.24.4",
-        "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.1",
-        "@babel/types": "^7.24.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -172,27 +135,28 @@
       }
     },
     "../../../node_modules/@babel/generator": {
-      "version": "7.24.4",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.0",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "../../../node_modules/@babel/helper-compilation-targets": {
-      "version": "7.23.6",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -208,58 +172,34 @@
         "semver": "bin/semver.js"
       }
     },
-    "../../../node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
+    "../../../node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../../../node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../../../node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "../../../node_modules/@babel/helper-module-imports": {
-      "version": "7.24.3",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.0"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "../../../node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -269,37 +209,15 @@
       }
     },
     "../../../node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.0",
+      "version": "7.28.6",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../../../node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "../../../node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "../../../node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -307,7 +225,7 @@
       }
     },
     "../../../node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -315,7 +233,7 @@
       }
     },
     "../../../node_modules/@babel/helper-validator-option": {
-      "version": "7.23.5",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -323,23 +241,23 @@
       }
     },
     "../../../node_modules/@babel/helpers": {
-      "version": "7.27.6",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "../../../node_modules/@babel/parser": {
-      "version": "7.27.5",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -381,6 +299,34 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "../../../node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "../../../node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "../../../node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "dev": true,
@@ -404,11 +350,11 @@
       }
     },
     "../../../node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.1",
+      "version": "7.28.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -483,6 +429,20 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "../../../node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "../../../node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
       "dev": true,
@@ -498,11 +458,11 @@
       }
     },
     "../../../node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.1",
+      "version": "7.28.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -512,53 +472,42 @@
       }
     },
     "../../../node_modules/@babel/template": {
-      "version": "7.27.2",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "../../../node_modules/@babel/traverse": {
-      "version": "7.24.1",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.1",
-        "@babel/generator": "^7.24.1",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.24.1",
-        "@babel/types": "^7.24.0",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "../../../node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "../../../node_modules/@babel/types": {
-      "version": "7.27.6",
+      "version": "7.29.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -600,8 +549,113 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "../../../node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../../../node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "../../../node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "../../../node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "../../../node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "../../../node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
+      "version": "4.9.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -618,7 +672,7 @@
       }
     },
     "../../../node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
+      "version": "4.12.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -626,20 +680,20 @@
       }
     },
     "../../../node_modules/@eslint/config-array": {
-      "version": "0.20.1",
+      "version": "0.21.2",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "../../../node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.15",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -648,7 +702,7 @@
       }
     },
     "../../../node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -659,26 +713,51 @@
       }
     },
     "../../../node_modules/@eslint/config-helpers": {
-      "version": "0.2.3",
+      "version": "0.4.2",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "../../../node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "../../../node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "../../../node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
+      "version": "3.3.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -689,7 +768,7 @@
       }
     },
     "../../../node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.15",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -709,7 +788,7 @@
       }
     },
     "../../../node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -720,7 +799,7 @@
       }
     },
     "../../../node_modules/@eslint/js": {
-      "version": "9.28.0",
+      "version": "9.39.4",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -730,23 +809,73 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "../../../node_modules/@eslint/json": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanwhocodes/momoa": "^3.3.10",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "../../../node_modules/@eslint/markdown": {
+      "version": "8.0.2",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "github-slugger": "^2.0.0",
+        "mdast-util-from-markdown": "^2.0.2",
+        "mdast-util-frontmatter": "^2.0.1",
+        "mdast-util-gfm": "^3.1.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "micromark-extension-math": "^3.1.0",
+        "micromark-util-normalize-identifier": "^2.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "../../../node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
+      "version": "2.1.7",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "../../../node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "../../../node_modules/@gerrit0/mini-shiki": {
-      "version": "3.2.2",
+      "version": "3.23.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.2.1",
-        "@shikijs/langs": "^3.2.1",
-        "@shikijs/themes": "^3.2.1",
-        "@shikijs/types": "^3.2.1",
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
@@ -794,6 +923,14 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "../../../node_modules/@humanwhocodes/momoa": {
+      "version": "3.3.10",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "../../../node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
       "dev": true,
@@ -807,57 +944,78 @@
       }
     },
     "../../../node_modules/@inrupt/base-rollup-config": {
-      "version": "3.2.7",
+      "version": "4.1.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rollup/plugin-typescript": "^12.1.2"
+        "@rollup/plugin-typescript": "^12.3.0"
       }
     },
     "../../../node_modules/@inrupt/eslint-config-base": {
-      "resolved": "../../../../typescript-sdk-tools/packages/eslint-config",
-      "link": true
-    },
-    "../../../node_modules/@inrupt/internal-playwright-helpers": {
-      "version": "3.2.7",
+      "version": "4.1.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inrupt/internal-playwright-testids": "3.2.7",
-        "@inrupt/internal-test-env": "3.2.7"
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "^9.39.2",
+        "@eslint/json": "^2.0.0",
+        "@eslint/markdown": "^8.0.2",
+        "eslint": "^9.28.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-header": "^3.1.1",
+        "eslint-plugin-headers": "^1.3.4",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jest": "^29.15.2",
+        "eslint-plugin-playwright": "^2.10.4",
+        "eslint-plugin-prettier": "^5.4.1",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "globals": "^17.6.0",
+        "jest": ">=30.4.2",
+        "prettier": ">=3.8.3",
+        "typescript-eslint": "^8.60.1"
+      },
+      "peerDependencies": {
+        "@rushstack/eslint-patch": ">=1.1.4",
+        "jest": ">=30.4.2",
+        "prettier": ">=3.8.3"
+      }
+    },
+    "../../../node_modules/@inrupt/eslint-config-base/node_modules/globals": {
+      "version": "17.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../node_modules/@inrupt/internal-playwright-helpers": {
+      "version": "4.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inrupt/internal-playwright-testids": "4.0.5",
+        "@inrupt/internal-test-env": "4.0.5"
       },
       "peerDependencies": {
         "@playwright/test": "^1.37.0"
       }
     },
-    "../../../node_modules/@inrupt/internal-playwright-testids": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../../node_modules/@inrupt/internal-test-env": {
-      "version": "3.2.7",
+    "../../../node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/internal-test-env": {
+      "version": "4.0.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.1.2",
-        "@inrupt/solid-client-authn-node": "^2.4.1",
+        "@inrupt/solid-client-authn-node": "^3.1.0",
         "deepmerge-json": "^1.5.0",
-        "dotenv": "^16.5.0"
+        "dotenv": "^17.2.0"
       }
     },
-    "../../../node_modules/@inrupt/jest-jsdom-polyfills": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@peculiar/webcrypto": "^1.5.0",
-        "@web-std/blob": "^3.0.5",
-        "@web-std/file": "^3.0.3",
-        "undici": "^7.8.0"
-      }
-    },
-    "../../../node_modules/@inrupt/solid-client": {
+    "../../../node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/solid-client": {
       "version": "2.1.2",
       "dev": true,
       "license": "MIT",
@@ -878,8 +1036,8 @@
         "fsevents": "^2.3.3"
       }
     },
-    "../../../node_modules/@inrupt/solid-client-authn-core": {
-      "version": "2.5.0",
+    "../../../node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/solid-client-authn-core": {
+      "version": "3.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -888,37 +1046,25 @@
         "uuid": "^11.1.0"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
+        "node": "^20.0.0 || ^22.0.0"
       }
     },
-    "../../../node_modules/@inrupt/solid-client-authn-core/node_modules/uuid": {
-      "version": "11.1.0",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "../../../node_modules/@inrupt/solid-client-authn-node": {
-      "version": "2.5.0",
+    "../../../node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/solid-client-authn-node": {
+      "version": "3.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client-authn-core": "^2.5.0",
+        "@inrupt/solid-client-authn-core": "^3.1.1",
         "jose": "^5.1.3",
         "openid-client": "^5.7.1",
         "uuid": "^11.1.0"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
+        "node": "^20.0.0 || ^22.0.0"
       }
     },
-    "../../../node_modules/@inrupt/solid-client-authn-node/node_modules/uuid": {
-      "version": "11.1.0",
+    "../../../node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/solid-client/node_modules/uuid": {
+      "version": "10.0.0",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -926,7 +1072,157 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "../../../node_modules/@inrupt/internal-playwright-helpers/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "../../../node_modules/@inrupt/internal-playwright-helpers/node_modules/jsonld-streaming-parser": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^3.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "../../../node_modules/@inrupt/internal-playwright-helpers/node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "../../../node_modules/@inrupt/internal-playwright-testids": {
+      "version": "4.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../node_modules/@inrupt/internal-test-env": {
+      "version": "4.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inrupt/solid-client": "^3.0.0",
+        "@inrupt/solid-client-authn-node": "^5.0.0",
+        "deepmerge-json": "^1.5.0",
+        "dotenv": "^17.4.2"
+      }
+    },
+    "../../../node_modules/@inrupt/jest-jsdom-polyfills": {
+      "version": "4.1.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.7.1",
+        "undici": "^8.3.0"
+      }
+    },
+    "../../../node_modules/@inrupt/solid-client": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inrupt/solid-client-errors": "^0.0.2",
+        "@rdfjs/dataset": "^1.1.1",
+        "buffer": "^6.0.3",
+        "http-link-header": "^1.1.1",
+        "jsonld-context-parser": "^3.0.0",
+        "jsonld-streaming-parser": "^5.0.0",
+        "n3": "^1.17.2",
+        "uuid": "^11.0.1"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "../../../node_modules/@inrupt/solid-client-authn-core": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "jose": "^6.2.3",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": "^22.0.0 || ^24.0.0"
+      }
+    },
+    "../../../node_modules/@inrupt/solid-client-authn-core/node_modules/jose": {
+      "version": "6.2.3",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "../../../node_modules/@inrupt/solid-client-authn-core/node_modules/uuid": {
+      "version": "14.0.1",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "../../../node_modules/@inrupt/solid-client-authn-node": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inrupt/solid-client-authn-core": "^5.0.0",
+        "jose": "^6.2.3",
+        "openid-client": "^5.7.1",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": "^22.0.0 || ^24.0.0"
+      }
+    },
+    "../../../node_modules/@inrupt/solid-client-authn-node/node_modules/jose": {
+      "version": "6.2.3",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "../../../node_modules/@inrupt/solid-client-authn-node/node_modules/uuid": {
+      "version": "14.0.1",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "../../../node_modules/@inrupt/solid-client-errors": {
@@ -934,6 +1230,22 @@
       "dev": true,
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
+      }
+    },
+    "../../../node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "../../../node_modules/@istanbuljs/load-nyc-config": {
@@ -972,7 +1284,7 @@
       }
     },
     "../../../node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
+      "version": "3.14.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1036,57 +1348,57 @@
       }
     },
     "../../../node_modules/@jest/console": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/core": {
-      "version": "29.7.0",
+      "version": "30.4.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/reporters": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.7.0",
-        "jest-config": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-resolve-dependencies": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -1097,105 +1409,158 @@
         }
       }
     },
+    "../../../node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "../../../node_modules/@jest/environment": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "^29.7.0"
+        "jest-mock": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "../../../node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "../../../node_modules/@jest/expect": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "^29.7.0",
-        "jest-snapshot": "^29.7.0"
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/expect-utils": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jest-get-type": "^29.6.3"
+        "@jest/get-type": "30.1.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/fake-timers": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@sinonjs/fake-timers": "^10.0.2",
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
         "@types/node": "*",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "../../../node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/globals": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/expect": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "jest-mock": "^29.7.0"
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "../../../node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/reporters": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-instrument": "^6.0.0",
         "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
         "slash": "^3.0.0",
-        "string-length": "^4.0.1",
-        "strip-ansi": "^6.0.0",
+        "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -1207,109 +1572,128 @@
       }
     },
     "../../../node_modules/@jest/schemas": {
-      "version": "29.6.3",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "../../../node_modules/@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/source-map": {
-      "version": "29.6.3",
+      "version": "30.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.9"
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/test-result": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "collect-v8-coverage": "^1.0.0"
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/test-sequencer": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
+        "@jest/test-result": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/transform": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
         "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
+        "write-file-atomic": "^5.0.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jest/types": {
-      "version": "29.6.3",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
+      "version": "0.3.12",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+      }
+    },
+    "../../../node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "../../../node_modules/@jridgewell/resolve-uri": {
@@ -1320,21 +1704,13 @@
         "node": ">=6.0.0"
       }
     },
-    "../../../node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "../../../node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
+      "version": "1.5.4",
       "dev": true,
       "license": "MIT"
     },
     "../../../node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
+      "version": "0.3.29",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1343,7 +1719,7 @@
       }
     },
     "../../../node_modules/@next/eslint-plugin-next": {
-      "version": "15.3.3",
+      "version": "16.2.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1409,13 +1785,13 @@
       }
     },
     "../../../node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.8",
+      "version": "2.7.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
       }
     },
     "../../../node_modules/@peculiar/json-schema": {
@@ -1429,27 +1805,55 @@
         "node": ">=8.0.0"
       }
     },
-    "../../../node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
+    "../../../node_modules/@peculiar/utils": {
+      "version": "2.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
+        "tslib": "^2.8.1"
+      }
+    },
+    "../../../node_modules/@peculiar/webcrypto": {
+      "version": "1.7.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
         "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
+        "@peculiar/utils": "^2.0.2",
+        "tslib": "^2.8.1",
+        "webcrypto-core": "^1.9.2"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=14.18.0"
+      }
+    },
+    "../../../node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "../../../node_modules/@pkgr/core": {
+      "version": "0.2.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "../../../node_modules/@playwright/test": {
-      "version": "1.52.0",
+      "version": "1.61.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.52.0"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1489,7 +1893,7 @@
       }
     },
     "../../../node_modules/@rollup/plugin-typescript": {
-      "version": "12.1.2",
+      "version": "12.3.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1514,7 +1918,7 @@
       }
     },
     "../../../node_modules/@rollup/pluginutils": {
-      "version": "5.1.4",
+      "version": "5.4.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1535,7 +1939,7 @@
       }
     },
     "../../../node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.2",
+      "version": "4.0.4",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1546,23 +1950,14 @@
       }
     },
     "../../../node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.43.0",
+      "version": "4.62.2",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "../../../node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.43.0",
-      "cpu": [
-        "x64"
+      "libc": [
+        "glibc"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1577,35 +1972,36 @@
     "../../../node_modules/@rushstack/eslint-patch": {
       "version": "1.10.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "../../../node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.2.1",
+      "version": "3.23.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1",
+        "@shikijs/types": "3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "../../../node_modules/@shikijs/langs": {
-      "version": "3.2.1",
+      "version": "3.23.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1"
+        "@shikijs/types": "3.23.0"
       }
     },
     "../../../node_modules/@shikijs/themes": {
-      "version": "3.2.1",
+      "version": "3.23.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1"
+        "@shikijs/types": "3.23.0"
       }
     },
     "../../../node_modules/@shikijs/types": {
-      "version": "3.2.1",
+      "version": "3.23.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1619,7 +2015,7 @@
       "license": "MIT"
     },
     "../../../node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
+      "version": "0.34.49",
       "dev": true,
       "license": "MIT"
     },
@@ -1632,19 +2028,11 @@
       }
     },
     "../../../node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
+      "version": "15.4.0",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "../../../node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
+        "@sinonjs/commons": "^3.0.1"
       }
     },
     "../../../node_modules/@tsconfig/node10": {
@@ -1680,7 +2068,7 @@
       }
     },
     "../../../node_modules/@types/babel__generator": {
-      "version": "7.6.8",
+      "version": "7.27.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1697,25 +2085,25 @@
       }
     },
     "../../../node_modules/@types/babel__traverse": {
-      "version": "7.20.5",
+      "version": "7.28.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "../../../node_modules/@types/debug": {
+      "version": "4.1.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
       }
     },
     "../../../node_modules/@types/estree": {
-      "version": "1.0.7",
+      "version": "1.0.9",
       "dev": true,
       "license": "MIT"
-    },
-    "../../../node_modules/@types/graceful-fs": {
-      "version": "4.1.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "../../../node_modules/@types/hast": {
       "version": "3.0.4",
@@ -1755,7 +2143,7 @@
       }
     },
     "../../../node_modules/@types/jsdom": {
-      "version": "20.0.1",
+      "version": "21.1.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1774,6 +2162,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "../../../node_modules/@types/katex": {
+      "version": "0.16.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "../../../node_modules/@types/ms": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "../../../node_modules/@types/node": {
       "version": "20.12.7",
       "dev": true,
@@ -1783,12 +2189,11 @@
       }
     },
     "../../../node_modules/@types/readable-stream": {
-      "version": "4.0.18",
+      "version": "4.0.23",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
+        "@types/node": "*"
       }
     },
     "../../../node_modules/@types/stack-utils": {
@@ -1807,7 +2212,7 @@
       "license": "MIT"
     },
     "../../../node_modules/@types/yargs": {
-      "version": "17.0.32",
+      "version": "17.0.33",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1820,19 +2225,18 @@
       "license": "MIT"
     },
     "../../../node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/type-utils": "8.34.0",
-        "@typescript-eslint/utils": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/type-utils": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1842,13 +2246,13 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.34.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "@typescript-eslint/parser": "^8.60.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "../../../node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.4",
+      "version": "7.0.5",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1856,15 +2260,15 @@
       }
     },
     "../../../node_modules/@typescript-eslint/parser": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/typescript-estree": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1874,18 +2278,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "../../../node_modules/@typescript-eslint/project-service": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.34.0",
-        "@typescript-eslint/types": "^8.34.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.60.1",
+        "@typescript-eslint/types": "^8.60.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1895,16 +2299,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "../../../node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0"
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1915,7 +2319,7 @@
       }
     },
     "../../../node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1926,18 +2330,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "../../../node_modules/@typescript-eslint/type-utils": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.34.0",
-        "@typescript-eslint/utils": "8.34.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1947,12 +2352,12 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "../../../node_modules/@typescript-eslint/types": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1964,20 +2369,19 @@
       }
     },
     "../../../node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.34.0",
-        "@typescript-eslint/tsconfig-utils": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.60.1",
+        "@typescript-eslint/tsconfig-utils": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1987,18 +2391,51 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "../../../node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../../../node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../../../node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "../../../node_modules/@typescript-eslint/utils": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/typescript-estree": "8.34.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2008,17 +2445,17 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "../../../node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.34.0",
+      "version": "8.60.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.34.0",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.60.1",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2029,11 +2466,11 @@
       }
     },
     "../../../node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
+      "version": "5.0.1",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2047,41 +2484,40 @@
         "typedoc": ">=0.25.0 || 0.26.x || 0.27.x || 0.28.x || 0.29.x || 0.30.x || 0.31.x"
       }
     },
-    "../../../node_modules/@web-std/blob": {
-      "version": "3.0.5",
+    "../../../node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
       "dev": true,
+      "license": "ISC"
+    },
+    "../../../node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
-      "dependencies": {
-        "@web-std/stream": "1.0.0",
-        "web-encoding": "1.1.5"
-      }
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
-    "../../../node_modules/@web-std/file": {
-      "version": "3.0.3",
+    "../../../node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
-      "dependencies": {
-        "@web-std/blob": "^3.0.3"
-      }
-    },
-    "../../../node_modules/@web-std/stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "web-streams-polyfill": "^3.1.1"
-      }
-    },
-    "../../../node_modules/@zxing/text-encoding": {
-      "version": "0.9.0",
-      "dev": true,
-      "license": "(Unlicense OR Apache-2.0)",
-      "optional": true
-    },
-    "../../../node_modules/abab": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "../../../node_modules/abort-controller": {
       "version": "3.0.0",
@@ -2105,15 +2541,6 @@
         "node": ">=0.4.0"
       }
     },
-    "../../../node_modules/acorn-globals": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.1.0",
-        "acorn-walk": "^8.0.2"
-      }
-    },
     "../../../node_modules/acorn-jsx": {
       "version": "5.3.2",
       "dev": true,
@@ -2131,18 +2558,15 @@
       }
     },
     "../../../node_modules/agent-base": {
-      "version": "6.0.2",
+      "version": "7.1.4",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "../../../node_modules/ajv": {
-      "version": "6.12.6",
+      "version": "6.14.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2182,11 +2606,14 @@
       }
     },
     "../../../node_modules/ansi-regex": {
-      "version": "5.0.1",
+      "version": "6.2.2",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "../../../node_modules/ansi-styles": {
@@ -2234,12 +2661,12 @@
       }
     },
     "../../../node_modules/array-buffer-byte-length": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "is-array-buffer": "^3.0.4"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2249,16 +2676,18 @@
       }
     },
     "../../../node_modules/array-includes": {
-      "version": "3.1.8",
+      "version": "3.1.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "is-string": "^1.0.7"
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2287,16 +2716,17 @@
       }
     },
     "../../../node_modules/array.prototype.findlastindex": {
-      "version": "1.2.5",
+      "version": "1.2.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2306,14 +2736,14 @@
       }
     },
     "../../../node_modules/array.prototype.flat": {
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2375,13 +2805,13 @@
       }
     },
     "../../../node_modules/asn1js": {
-      "version": "3.0.5",
+      "version": "3.0.10",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2389,16 +2819,6 @@
     },
     "../../../node_modules/ast-types-flow": {
       "version": "0.0.8",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../../node_modules/async": {
-      "version": "3.2.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../../node_modules/asynckit": {
-      "version": "0.4.0",
       "dev": true,
       "license": "MIT"
     },
@@ -2433,112 +2853,92 @@
       }
     },
     "../../../node_modules/babel-jest": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "^29.7.0",
-        "@types/babel__core": "^7.1.14",
-        "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.6.3",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.8.0"
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
       }
     },
     "../../../node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
+      "version": "7.0.1",
       "dev": true,
       "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
         "test-exclude": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../../node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "../../../node_modules/babel-plugin-istanbul/node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=12"
       }
     },
     "../../../node_modules/babel-plugin-jest-hoist": {
-      "version": "29.6.3",
+      "version": "30.4.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.3.3",
-        "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.1.14",
-        "@types/babel__traverse": "^7.0.6"
+        "@types/babel__core": "^7.20.5"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/babel-preset-current-node-syntax": {
-      "version": "1.0.1",
+      "version": "1.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
     "../../../node_modules/babel-preset-jest": {
-      "version": "29.6.3",
+      "version": "30.4.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-jest-hoist": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0"
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
     "../../../node_modules/balanced-match": {
@@ -2565,8 +2965,19 @@
       ],
       "license": "MIT"
     },
+    "../../../node_modules/baseline-browser-mapping": {
+      "version": "2.10.37",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "../../../node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2585,7 +2996,7 @@
       }
     },
     "../../../node_modules/browserslist": {
-      "version": "4.23.0",
+      "version": "4.28.2",
       "dev": true,
       "funding": [
         {
@@ -2603,10 +3014,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2723,7 +3135,7 @@
       }
     },
     "../../../node_modules/caniuse-lite": {
-      "version": "1.0.30001612",
+      "version": "1.0.30001799",
       "dev": true,
       "funding": [
         {
@@ -2745,6 +3157,15 @@
       "version": "1.0.8",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "../../../node_modules/ccount": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "../../../node_modules/chalk": {
       "version": "4.1.2",
@@ -2769,8 +3190,17 @@
         "node": ">=10"
       }
     },
+    "../../../node_modules/character-entities": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "../../../node_modules/ci-info": {
-      "version": "3.9.0",
+      "version": "4.3.0",
       "dev": true,
       "funding": [
         {
@@ -2784,7 +3214,7 @@
       }
     },
     "../../../node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
+      "version": "2.2.0",
       "dev": true,
       "license": "MIT"
     },
@@ -2801,6 +3231,59 @@
         "node": ">=12"
       }
     },
+    "../../../node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "../../../node_modules/co": {
       "version": "4.6.0",
       "dev": true,
@@ -2811,7 +3294,7 @@
       }
     },
     "../../../node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "license": "MIT"
     },
@@ -2831,15 +3314,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "../../../node_modules/combined-stream": {
-      "version": "1.0.8",
+    "../../../node_modules/commander": {
+      "version": "8.3.0",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 12"
       }
     },
     "../../../node_modules/concat-map": {
@@ -2851,26 +3331,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "../../../node_modules/create-jest": {
-      "version": "29.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-config": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "prompts": "^2.0.1"
-      },
-      "bin": {
-        "create-jest": "bin/create-jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
     },
     "../../../node_modules/create-require": {
       "version": "1.1.1",
@@ -2890,26 +3350,17 @@
         "node": ">= 8"
       }
     },
-    "../../../node_modules/cssom": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "../../../node_modules/cssstyle": {
-      "version": "2.3.0",
+      "version": "4.6.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssom": "~0.3.6"
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
-    },
-    "../../../node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "dev": true,
-      "license": "MIT"
     },
     "../../../node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2917,26 +3368,25 @@
       "license": "BSD-2-Clause"
     },
     "../../../node_modules/data-urls": {
-      "version": "3.0.2",
+      "version": "5.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "../../../node_modules/data-view-buffer": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2946,27 +3396,27 @@
       }
     },
     "../../../node_modules/data-view-byte-length": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
+        "is-data-view": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/inspect-js"
       }
     },
     "../../../node_modules/data-view-byte-offset": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
       },
@@ -2978,11 +3428,11 @@
       }
     },
     "../../../node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.4.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2994,12 +3444,24 @@
       }
     },
     "../../../node_modules/decimal.js": {
-      "version": "10.4.3",
+      "version": "10.6.0",
       "dev": true,
       "license": "MIT"
     },
+    "../../../node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "../../../node_modules/dedent": {
-      "version": "1.5.3",
+      "version": "1.7.2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3064,12 +3526,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "../../../node_modules/delayed-stream": {
-      "version": "1.0.0",
+    "../../../node_modules/dequal": {
+      "version": "2.0.3",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=6"
       }
     },
     "../../../node_modules/detect-newline": {
@@ -3080,35 +3542,28 @@
         "node": ">=8"
       }
     },
+    "../../../node_modules/devlop": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "../../../node_modules/diff": {
-      "version": "4.0.2",
+      "version": "4.0.4",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
-    "../../../node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "../../../node_modules/domexception": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "../../../node_modules/dotenv": {
-      "version": "16.5.0",
+      "version": "17.4.2",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -3131,22 +3586,13 @@
         "node": ">= 0.4"
       }
     },
-    "../../../node_modules/ejs": {
-      "version": "3.1.10",
+    "../../../node_modules/eastasianwidth": {
+      "version": "0.2.0",
       "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "license": "MIT"
     },
     "../../../node_modules/electron-to-chromium": {
-      "version": "1.4.746",
+      "version": "1.5.373",
       "dev": true,
       "license": "ISC"
     },
@@ -3162,7 +3608,7 @@
       }
     },
     "../../../node_modules/emoji-regex": {
-      "version": "8.0.0",
+      "version": "9.2.2",
       "dev": true,
       "license": "MIT"
     },
@@ -3190,7 +3636,7 @@
       }
     },
     "../../../node_modules/error-ex": {
-      "version": "1.3.2",
+      "version": "1.3.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3198,26 +3644,27 @@
       }
     },
     "../../../node_modules/es-abstract": {
-      "version": "1.23.6",
+      "version": "1.24.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
+        "array-buffer-byte-length": "^1.0.2",
         "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "data-view-buffer": "^1.0.1",
-        "data-view-byte-length": "^1.0.1",
-        "data-view-byte-offset": "^1.0.0",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-set-tostringtag": "^2.0.3",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
         "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.7",
-        "get-intrinsic": "^1.2.6",
-        "get-symbol-description": "^1.0.2",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
         "has-property-descriptors": "^1.0.2",
@@ -3225,31 +3672,36 @@
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
         "internal-slot": "^1.1.0",
-        "is-array-buffer": "^3.0.4",
+        "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
         "is-data-view": "^1.0.2",
         "is-negative-zero": "^2.0.3",
         "is-regex": "^1.2.1",
-        "is-shared-array-buffer": "^1.0.3",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
         "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.13",
-        "is-weakref": "^1.1.0",
-        "math-intrinsics": "^1.0.0",
-        "object-inspect": "^1.13.3",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.5",
-        "regexp.prototype.flags": "^1.5.3",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
         "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
         "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
         "string.prototype.trim": "^1.2.10",
         "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.2",
-        "typed-array-byte-length": "^1.0.1",
-        "typed-array-byte-offset": "^1.0.3",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
         "typed-array-length": "^1.0.7",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.16"
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3312,24 +3764,28 @@
       }
     },
     "../../../node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
+      "version": "2.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "../../../node_modules/es-shim-unscopables": {
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "../../../node_modules/es-to-primitive": {
@@ -3349,7 +3805,7 @@
       }
     },
     "../../../node_modules/escalade": {
-      "version": "3.1.2",
+      "version": "3.2.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3367,52 +3823,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../node_modules/escodegen": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
     "../../../node_modules/eslint": {
-      "version": "9.28.0",
+      "version": "9.39.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.14.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.28.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3424,7 +3859,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3447,29 +3882,42 @@
       }
     },
     "../../../node_modules/eslint-config-next": {
-      "version": "15.3.3",
+      "version": "16.2.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.3.3",
-        "@rushstack/eslint-patch": "^1.10.3",
-        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@next/eslint-plugin-next": "16.2.9",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.37.0",
-        "eslint-plugin-react-hooks": "^5.0.0"
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
       },
       "peerDependencies": {
-        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
+        "eslint": ">=9.0.0",
         "typescript": ">=3.3.1"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "../../../node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "../../../node_modules/eslint-import-resolver-node": {
@@ -3515,7 +3963,7 @@
       }
     },
     "../../../node_modules/eslint-module-utils": {
-      "version": "2.12.0",
+      "version": "2.12.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3538,29 +3986,48 @@
         "ms": "^2.1.1"
       }
     },
+    "../../../node_modules/eslint-plugin-header": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7.7.0"
+      }
+    },
+    "../../../node_modules/eslint-plugin-headers": {
+      "version": "1.3.4",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^16.0.0 || >= 18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7"
+      }
+    },
     "../../../node_modules/eslint-plugin-import": {
-      "version": "2.31.0",
+      "version": "2.32.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.8",
-        "array.prototype.findlastindex": "^1.2.5",
-        "array.prototype.flat": "^1.3.2",
-        "array.prototype.flatmap": "^1.3.2",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.0",
+        "eslint-module-utils": "^2.12.1",
         "hasown": "^2.0.2",
-        "is-core-module": "^2.15.1",
+        "is-core-module": "^2.16.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
         "object.fromentries": "^2.0.8",
         "object.groupby": "^1.0.3",
-        "object.values": "^1.2.0",
+        "object.values": "^1.2.1",
         "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimend": "^1.0.9",
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
@@ -3571,7 +4038,7 @@
       }
     },
     "../../../node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.15",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3599,7 +4066,7 @@
       }
     },
     "../../../node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3615,6 +4082,34 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "../../../node_modules/eslint-plugin-jest": {
+      "version": "29.15.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "engines": {
+        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "jest": "*",
+        "typescript": ">=4.8.4 <7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "../../../node_modules/eslint-plugin-jsx-a11y": {
@@ -3646,7 +4141,7 @@
       }
     },
     "../../../node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.15",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3654,13 +4149,8 @@
         "concat-map": "0.0.1"
       }
     },
-    "../../../node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "../../../node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3668,6 +4158,60 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "../../../node_modules/eslint-plugin-playwright": {
+      "version": "2.10.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^17.3.0"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "../../../node_modules/eslint-plugin-playwright/node_modules/globals": {
+      "version": "17.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../node_modules/eslint-plugin-prettier": {
+      "version": "5.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "../../../node_modules/eslint-plugin-react": {
@@ -3702,18 +4246,25 @@
       }
     },
     "../../../node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
+      "version": "7.1.1",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "../../../node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.15",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3733,7 +4284,7 @@
       }
     },
     "../../../node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3794,7 +4345,7 @@
       }
     },
     "../../../node_modules/eslint/node_modules/@eslint/core": {
-      "version": "0.14.0",
+      "version": "0.17.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3805,30 +4356,19 @@
       }
     },
     "../../../node_modules/eslint/node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
+      "version": "0.4.1",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "../../../node_modules/eslint/node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "../../../node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.15",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3848,7 +4388,7 @@
       }
     },
     "../../../node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3978,32 +4518,44 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "../../../node_modules/exit": {
-      "version": "0.1.2",
+    "../../../node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
       "dev": true,
+      "license": "ISC"
+    },
+    "../../../node_modules/exit-x": {
+      "version": "0.2.2",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "../../../node_modules/expect": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0"
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "../../../node_modules/fast-diff": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "../../../node_modules/fast-glob": {
       "version": "3.3.2",
@@ -4049,6 +4601,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "../../../node_modules/fault": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "../../../node_modules/fb-watchman": {
       "version": "2.0.2",
       "dev": true,
@@ -4066,25 +4630,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "../../../node_modules/filelist": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "../../../node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "../../../node_modules/fill-range": {
@@ -4126,29 +4671,44 @@
       }
     },
     "../../../node_modules/flatted": {
-      "version": "3.3.3",
+      "version": "3.4.2",
       "dev": true,
       "license": "ISC"
     },
     "../../../node_modules/for-each": {
-      "version": "0.3.3",
+      "version": "0.3.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
-      }
-    },
-    "../../../node_modules/form-data": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "is-callable": "^1.2.7"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "../../../node_modules/foreground-child": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../../node_modules/format": {
+      "version": "0.2.2",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "../../../node_modules/fs.realpath": {
@@ -4165,11 +4725,12 @@
       }
     },
     "../../../node_modules/function.prototype.name": {
-      "version": "1.1.7",
+      "version": "1.1.8",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
         "functions-have-names": "^1.2.3",
         "hasown": "^2.0.2",
@@ -4261,13 +4822,13 @@
       }
     },
     "../../../node_modules/get-symbol-description": {
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4"
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4287,20 +4848,25 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "../../../node_modules/github-slugger": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
     "../../../node_modules/glob": {
-      "version": "7.2.3",
+      "version": "10.5.0",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": "*"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4317,24 +4883,15 @@
         "node": ">=10.13.0"
       }
     },
-    "../../../node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
+    "../../../node_modules/globals": {
+      "version": "16.4.0",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "../../../node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
       "engines": {
-        "node": "*"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "../../../node_modules/globalthis": {
@@ -4368,13 +4925,8 @@
       "dev": true,
       "license": "ISC"
     },
-    "../../../node_modules/graphemer": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "../../../node_modules/handlebars": {
-      "version": "4.7.8",
+      "version": "4.7.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4470,15 +5022,28 @@
         "node": ">= 0.4"
       }
     },
-    "../../../node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
+    "../../../node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../node_modules/hermes-parser": {
+      "version": "0.25.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^2.0.0"
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "../../../node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "../../../node_modules/html-escaper": {
@@ -4495,28 +5060,27 @@
       }
     },
     "../../../node_modules/http-proxy-agent": {
-      "version": "5.0.0",
+      "version": "7.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "../../../node_modules/https-proxy-agent": {
-      "version": "5.0.1",
+      "version": "7.0.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "../../../node_modules/human-signals": {
@@ -4581,7 +5145,7 @@
       }
     },
     "../../../node_modules/import-local": {
-      "version": "3.1.0",
+      "version": "3.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4633,28 +5197,14 @@
         "node": ">= 0.4"
       }
     },
-    "../../../node_modules/is-arguments": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "../../../node_modules/is-array-buffer": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4723,7 +5273,7 @@
       }
     },
     "../../../node_modules/is-core-module": {
-      "version": "2.15.1",
+      "version": "2.16.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4909,11 +5459,11 @@
       }
     },
     "../../../node_modules/is-shared-array-buffer": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4965,11 +5515,11 @@
       }
     },
     "../../../node_modules/is-typed-array": {
-      "version": "1.1.13",
+      "version": "1.1.15",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4990,11 +5540,11 @@
       }
     },
     "../../../node_modules/is-weakref": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5037,7 +5587,7 @@
       }
     },
     "../../../node_modules/istanbul-lib-instrument": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5065,20 +5615,20 @@
       }
     },
     "../../../node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.1",
+      "version": "5.0.6",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
         "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
+        "istanbul-lib-coverage": "^3.0.0"
       },
       "engines": {
         "node": ">=10"
       }
     },
     "../../../node_modules/istanbul-reports": {
-      "version": "3.1.7",
+      "version": "3.2.0",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5105,58 +5655,35 @@
         "node": ">= 0.4"
       }
     },
-    "../../../node_modules/jake": {
-      "version": "10.9.1",
+    "../../../node_modules/jackspeak": {
+      "version": "3.4.3",
       "dev": true,
-      "license": "Apache-2.0",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
+        "@isaacs/cliui": "^8.0.2"
       },
-      "bin": {
-        "jake": "bin/cli.js"
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "../../../node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "../../../node_modules/jake/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "../../../node_modules/jest": {
-      "version": "29.7.0",
+      "version": "30.4.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "import-local": "^3.0.2",
-        "jest-cli": "^29.7.0"
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.4.2"
       },
       "bin": {
         "jest": "bin/jest.js"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -5168,70 +5695,69 @@
       }
     },
     "../../../node_modules/jest-changed-files": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "execa": "^5.0.0",
-        "jest-util": "^29.7.0",
+        "execa": "^5.1.1",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-circus": {
-      "version": "29.7.0",
+      "version": "30.4.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/expect": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.2",
         "co": "^4.6.0",
-        "dedent": "^1.0.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.7.0",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.7.0",
-        "pure-rand": "^6.0.0",
+        "pretty-format": "30.4.1",
+        "pure-rand": "^7.0.0",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
+        "stack-utils": "^2.0.6"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-cli": {
-      "version": "29.7.0",
+      "version": "30.4.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "create-jest": "^29.7.0",
-        "exit": "^0.1.2",
-        "import-local": "^3.0.2",
-        "jest-config": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "yargs": "^17.3.1"
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "jest": "bin/jest.js"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
         "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -5243,42 +5769,47 @@
       }
     },
     "../../../node_modules/jest-config": {
-      "version": "29.7.0",
+      "version": "30.4.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-jest": "^29.7.0",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "micromatch": "^4.0.4",
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.7.0",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
         "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
         "ts-node": ">=9.0.0"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
           "optional": true
         },
         "ts-node": {
@@ -5287,64 +5818,59 @@
       }
     },
     "../../../node_modules/jest-diff": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-docblock": {
-      "version": "29.7.0",
+      "version": "30.4.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "detect-newline": "^3.0.0"
+        "detect-newline": "^3.1.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-each": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "pretty-format": "^29.7.0"
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-environment-jsdom": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/jsdom": "^20.0.0",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jsdom": "^20.0.0"
+        "@jest/environment": "30.4.1",
+        "@jest/environment-jsdom-abstract": "30.4.1",
+        "jsdom": "^26.1.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "canvas": "^2.5.0"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -5353,109 +5879,124 @@
       }
     },
     "../../../node_modules/jest-environment-node": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "../../../node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-haste-map": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
         "walker": "^1.0.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "^2.3.2"
+        "fsevents": "^2.3.3"
+      }
+    },
+    "../../../node_modules/jest-haste-map/node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "../../../node_modules/jest-leak-detector": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-matcher-utils": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-message-util": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
+        "stack-utils": "^2.0.6"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "../../../node_modules/jest-message-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "../../../node_modules/jest-mock": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-util": "^29.7.0"
+        "jest-util": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-pnp-resolver": {
@@ -5475,167 +6016,179 @@
       }
     },
     "../../../node_modules/jest-regex-util": {
-      "version": "29.6.3",
+      "version": "30.4.0",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-resolve": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "resolve": "^1.20.0",
-        "resolve.exports": "^2.0.0",
-        "slash": "^3.0.0"
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-resolve-dependencies": {
-      "version": "29.7.0",
+      "version": "30.4.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jest-regex-util": "^29.6.3",
-        "jest-snapshot": "^29.7.0"
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-runner": {
-      "version": "29.7.0",
+      "version": "30.4.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/environment": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-leak-detector": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-resolve": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "jest-worker": "^29.7.0",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-runtime": {
-      "version": "29.7.0",
+      "version": "30.4.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/globals": "^29.7.0",
-        "@jest/source-map": "^29.6.3",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "cjs-module-lexer": "^1.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-snapshot": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@babel/generator": "^7.7.2",
-        "@babel/plugin-syntax-jsx": "^7.7.2",
-        "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0",
-        "chalk": "^4.0.0",
-        "expect": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^29.7.0",
-        "semver": "^7.5.3"
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-util": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "../../../node_modules/jest-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "../../../node_modules/jest-validate": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^29.6.3",
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
         "leven": "^3.1.0",
-        "pretty-format": "^29.7.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-validate/node_modules/camelcase": {
@@ -5650,35 +6203,36 @@
       }
     },
     "../../../node_modules/jest-watcher": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "jest-util": "^29.7.0",
-        "string-length": "^4.0.1"
+        "jest-util": "30.4.1",
+        "string-length": "^4.0.2"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-worker": {
-      "version": "29.7.0",
+      "version": "30.4.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.7.0",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.4.1",
         "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
+        "supports-color": "^8.1.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/jest-worker/node_modules/supports-color": {
@@ -5709,8 +6263,18 @@
       "license": "MIT"
     },
     "../../../node_modules/js-yaml": {
-      "version": "4.1.0",
+      "version": "4.2.0",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5720,42 +6284,36 @@
       }
     },
     "../../../node_modules/jsdom": {
-      "version": "20.0.3",
+      "version": "26.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.1",
-        "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
-        "xml-name-validator": "^4.0.0"
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.5.0"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -5764,14 +6322,14 @@
       }
     },
     "../../../node_modules/jsesc": {
-      "version": "2.5.2",
+      "version": "3.1.0",
       "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "../../../node_modules/json-buffer": {
@@ -5806,7 +6364,7 @@
       }
     },
     "../../../node_modules/jsonld-context-parser": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5817,10 +6375,14 @@
       },
       "bin": {
         "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "../../../node_modules/jsonld-context-parser/node_modules/@types/node": {
-      "version": "18.19.80",
+      "version": "18.19.130",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5828,19 +6390,18 @@
       }
     },
     "../../../node_modules/jsonld-streaming-parser": {
-      "version": "4.0.1",
+      "version": "5.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
-        "@rdfjs/types": "*",
         "@types/http-link-header": "^1.0.1",
         "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^3.0.0",
-        "rdf-data-factory": "^1.1.0",
+        "jsonld-context-parser": "^3.1.0",
+        "rdf-data-factory": "^2.0.0",
         "readable-stream": "^4.0.0"
       },
       "funding": {
@@ -5862,20 +6423,27 @@
         "node": ">=4.0"
       }
     },
+    "../../../node_modules/katex": {
+      "version": "0.16.47",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "../../../node_modules/keyv": {
       "version": "4.5.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "../../../node_modules/kleur": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "../../../node_modules/language-subtag-registry": {
@@ -5920,8 +6488,18 @@
       "license": "MIT"
     },
     "../../../node_modules/linkify-it": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -5950,6 +6528,15 @@
       "version": "4.6.2",
       "dev": true,
       "license": "MIT"
+    },
+    "../../../node_modules/longest-streak": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "../../../node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6003,13 +6590,23 @@
       }
     },
     "../../../node_modules/markdown-it": {
-      "version": "14.1.0",
+      "version": "14.2.0",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -6018,12 +6615,256 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "../../../node_modules/markdown-table": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "../../../node_modules/math-intrinsics": {
       "version": "1.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "../../../node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "../../../node_modules/mdurl": {
@@ -6044,6 +6885,574 @@
         "node": ">= 8"
       }
     },
+    "../../../node_modules/micromark": {
+      "version": "4.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../../../node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../../../node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "../../../node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../../../node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "../../../node_modules/micromatch": {
       "version": "4.0.8",
       "dev": true,
@@ -6056,25 +7465,6 @@
         "node": ">=8.6"
       }
     },
-    "../../../node_modules/mime-db": {
-      "version": "1.52.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "../../../node_modules/mime-types": {
-      "version": "2.1.35",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "../../../node_modules/mimic-fn": {
       "version": "2.1.0",
       "dev": true,
@@ -6084,11 +7474,11 @@
       }
     },
     "../../../node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6105,22 +7495,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "../../../node_modules/minipass": {
+      "version": "7.1.3",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "../../../node_modules/ms": {
-      "version": "2.1.2",
+      "version": "2.1.3",
       "dev": true,
       "license": "MIT"
     },
     "../../../node_modules/n3": {
-      "version": "1.24.2",
+      "version": "1.26.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
-        "queue-microtask": "^1.1.2",
         "readable-stream": "^4.0.0"
       },
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "../../../node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
       }
     },
     "../../../node_modules/natural-compare": {
@@ -6139,9 +7550,12 @@
       "license": "MIT"
     },
     "../../../node_modules/node-releases": {
-      "version": "2.0.14",
+      "version": "2.0.47",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "../../../node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6163,7 +7577,7 @@
       }
     },
     "../../../node_modules/nwsapi": {
-      "version": "2.2.9",
+      "version": "2.2.23",
       "dev": true,
       "license": "MIT"
     },
@@ -6184,7 +7598,7 @@
       }
     },
     "../../../node_modules/object-inspect": {
-      "version": "1.13.3",
+      "version": "1.13.4",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6203,13 +7617,15 @@
       }
     },
     "../../../node_modules/object.assign": {
-      "version": "4.1.5",
+      "version": "4.1.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -6281,7 +7697,7 @@
       }
     },
     "../../../node_modules/oidc-token-hash": {
-      "version": "5.1.0",
+      "version": "5.2.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6364,6 +7780,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "../../../node_modules/own-keys": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "../../../node_modules/p-limit": {
       "version": "3.1.0",
       "dev": true,
@@ -6400,6 +7832,11 @@
         "node": ">=6"
       }
     },
+    "../../../node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "../../../node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -6429,14 +7866,25 @@
       }
     },
     "../../../node_modules/parse5": {
-      "version": "7.1.2",
+      "version": "7.3.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "../../../node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "../../../node_modules/path-exists": {
@@ -6468,13 +7916,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "../../../node_modules/path-scurry": {
+      "version": "1.11.1",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../../node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "dev": true,
+      "license": "ISC"
+    },
     "../../../node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
       "license": "ISC"
     },
     "../../../node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6485,7 +7953,7 @@
       }
     },
     "../../../node_modules/pirates": {
-      "version": "4.0.6",
+      "version": "4.0.7",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6552,11 +8020,11 @@
       }
     },
     "../../../node_modules/playwright": {
-      "version": "1.52.0",
+      "version": "1.61.0",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.52.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6569,7 +8037,7 @@
       }
     },
     "../../../node_modules/playwright-core": {
-      "version": "1.52.0",
+      "version": "1.61.0",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6595,17 +8063,43 @@
         "node": ">= 0.8.0"
       }
     },
-    "../../../node_modules/pretty-format": {
-      "version": "29.7.0",
+    "../../../node_modules/prettier": {
+      "version": "3.8.3",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "../../../node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "fast-diff": "^1.1.2"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": ">=6.0.0"
+      }
+    },
+    "../../../node_modules/pretty-format": {
+      "version": "30.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "../../../node_modules/pretty-format/node_modules/ansi-styles": {
@@ -6627,18 +8121,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "../../../node_modules/prompts": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "../../../node_modules/prop-types": {
       "version": "15.8.1",
       "dev": true,
@@ -6651,11 +8133,6 @@
     },
     "../../../node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../../node_modules/psl": {
-      "version": "1.9.0",
       "dev": true,
       "license": "MIT"
     },
@@ -6676,7 +8153,7 @@
       }
     },
     "../../../node_modules/pure-rand": {
-      "version": "6.1.0",
+      "version": "7.0.1",
       "dev": true,
       "funding": [
         {
@@ -6691,25 +8168,20 @@
       "license": "MIT"
     },
     "../../../node_modules/pvtsutils": {
-      "version": "1.3.5",
+      "version": "1.3.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.6.1"
+        "tslib": "^2.8.1"
       }
     },
     "../../../node_modules/pvutils": {
-      "version": "1.1.3",
+      "version": "1.1.5",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=16.0.0"
       }
-    },
-    "../../../node_modules/querystringify": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "../../../node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6731,23 +8203,26 @@
       "license": "MIT"
     },
     "../../../node_modules/rdf-data-factory": {
-      "version": "1.1.3",
+      "version": "2.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rdfjs/types": "^1.0.0"
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
-    "../../../node_modules/rdf-data-factory/node_modules/@rdfjs/types": {
-      "version": "1.1.2",
+    "../../../node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
+      "license": "MIT"
     },
-    "../../../node_modules/react-is": {
-      "version": "18.2.0",
+    "../../../node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.6",
       "dev": true,
       "license": "MIT"
     },
@@ -6767,18 +8242,18 @@
       }
     },
     "../../../node_modules/reflect.getprototypeof": {
-      "version": "1.0.8",
+      "version": "1.0.10",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
-        "dunder-proto": "^1.0.0",
-        "es-abstract": "^1.23.5",
+        "es-abstract": "^1.23.9",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.2.0",
-        "which-builtin-type": "^1.2.0"
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6788,13 +8263,15 @@
       }
     },
     "../../../node_modules/regexp.prototype.flags": {
-      "version": "1.5.3",
+      "version": "1.5.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "set-function-name": "^2.0.2"
       },
       "engines": {
@@ -6805,9 +8282,13 @@
       }
     },
     "../../../node_modules/relative-to-absolute-iri": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
     },
     "../../../node_modules/require-directory": {
       "version": "2.1.1",
@@ -6816,11 +8297,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "../../../node_modules/requires-port": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "../../../node_modules/resolve": {
       "version": "1.22.8",
@@ -6873,14 +8349,6 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "../../../node_modules/resolve.exports": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "../../../node_modules/reusify": {
       "version": "1.0.4",
       "dev": true,
@@ -6891,11 +8359,11 @@
       }
     },
     "../../../node_modules/rollup": {
-      "version": "4.43.0",
+      "version": "4.62.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.7"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -6905,28 +8373,38 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.43.0",
-        "@rollup/rollup-android-arm64": "4.43.0",
-        "@rollup/rollup-darwin-arm64": "4.43.0",
-        "@rollup/rollup-darwin-x64": "4.43.0",
-        "@rollup/rollup-freebsd-arm64": "4.43.0",
-        "@rollup/rollup-freebsd-x64": "4.43.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.43.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.43.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.43.0",
-        "@rollup/rollup-linux-arm64-musl": "4.43.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.43.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.43.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.43.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.43.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.43.0",
-        "@rollup/rollup-linux-x64-gnu": "4.43.0",
-        "@rollup/rollup-linux-x64-musl": "4.43.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.43.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.43.0",
-        "@rollup/rollup-win32-x64-msvc": "4.43.0",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "../../../node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "dev": true,
+      "license": "MIT"
     },
     "../../../node_modules/run-parallel": {
       "version": "1.2.0",
@@ -6969,9 +8447,38 @@
       }
     },
     "../../../node_modules/safe-buffer": {
-      "version": "5.1.2",
+      "version": "5.2.1",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
+    },
+    "../../../node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "../../../node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -7006,7 +8513,7 @@
       }
     },
     "../../../node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.8.0",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7041,6 +8548,19 @@
         "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "../../../node_modules/set-proto": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7134,14 +8654,15 @@
       }
     },
     "../../../node_modules/signal-exit": {
-      "version": "3.0.7",
+      "version": "4.1.0",
       "dev": true,
-      "license": "ISC"
-    },
-    "../../../node_modules/sisteransi": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT"
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "../../../node_modules/slash": {
       "version": "3.0.0",
@@ -7192,6 +8713,18 @@
         "node": ">=8"
       }
     },
+    "../../../node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "../../../node_modules/string_decoder": {
       "version": "1.3.0",
       "dev": true,
@@ -7199,25 +8732,6 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
-    },
-    "../../../node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "../../../node_modules/string-length": {
       "version": "4.0.2",
@@ -7231,7 +8745,43 @@
         "node": ">=10"
       }
     },
+    "../../../node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "../../../node_modules/string-width": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "dev": true,
       "license": "MIT",
@@ -7239,6 +8789,30 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -7346,12 +8920,35 @@
       }
     },
     "../../../node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "../../../node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7410,6 +9007,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "../../../node_modules/synckit": {
+      "version": "0.11.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
     "../../../node_modules/tapable": {
       "version": "2.2.1",
       "dev": true,
@@ -7432,7 +9043,7 @@
       }
     },
     "../../../node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.15",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7440,8 +9051,27 @@
         "concat-map": "0.0.1"
       }
     },
+    "../../../node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "../../../node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7450,6 +9080,64 @@
       "engines": {
         "node": "*"
       }
+    },
+    "../../../node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "../../../node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "../../../node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "../../../node_modules/tldts": {
+      "version": "6.1.86",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "../../../node_modules/tldts-core": {
+      "version": "6.1.86",
+      "dev": true,
+      "license": "MIT"
     },
     "../../../node_modules/tmpl": {
       "version": "1.0.5",
@@ -7468,32 +9156,29 @@
       }
     },
     "../../../node_modules/tough-cookie": {
-      "version": "4.1.3",
+      "version": "5.1.2",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=16"
       }
     },
     "../../../node_modules/tr46": {
-      "version": "3.0.0",
+      "version": "5.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "../../../node_modules/ts-api-utils": {
-      "version": "2.1.0",
+      "version": "2.5.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7504,18 +9189,17 @@
       }
     },
     "../../../node_modules/ts-jest": {
-      "version": "29.3.4",
+      "version": "29.4.11",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.2",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -7527,11 +9211,12 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
-        "typescript": ">=4.3 <6"
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -7547,6 +9232,9 @@
           "optional": true
         },
         "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
           "optional": true
         }
       }
@@ -7659,28 +9347,28 @@
       }
     },
     "../../../node_modules/typed-array-buffer": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.13"
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "../../../node_modules/typed-array-byte-length": {
-      "version": "1.0.1",
+      "version": "1.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7690,17 +9378,17 @@
       }
     },
     "../../../node_modules/typed-array-byte-offset": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-proto": "^1.0.3",
-        "is-typed-array": "^1.1.13",
-        "reflect.getprototypeof": "^1.0.6"
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7729,15 +9417,15 @@
       }
     },
     "../../../node_modules/typedoc": {
-      "version": "0.28.5",
+      "version": "0.28.19",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.2.2",
+        "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
-        "markdown-it": "^14.1.0",
-        "minimatch": "^9.0.5",
-        "yaml": "^2.7.1"
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -7747,7 +9435,7 @@
         "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
       }
     },
     "../../../node_modules/typedoc-plugin-markdown": {
@@ -7761,8 +9449,41 @@
         "typedoc": ">=0.24.0"
       }
     },
+    "../../../node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../../../node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "../../../node_modules/typedoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "../../../node_modules/typescript": {
-      "version": "5.8.3",
+      "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7771,6 +9492,28 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "../../../node_modules/typescript-eslint": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.60.1",
+        "@typescript-eslint/parser": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "../../../node_modules/uc.micro": {
@@ -7791,25 +9534,28 @@
       }
     },
     "../../../node_modules/unbox-primitive": {
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "../../../node_modules/undici": {
-      "version": "7.8.0",
+      "version": "8.5.0",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "../../../node_modules/undici-types": {
@@ -7817,16 +9563,105 @@
       "dev": true,
       "license": "MIT"
     },
-    "../../../node_modules/universalify": {
-      "version": "0.2.0",
+    "../../../node_modules/unist-util-is": {
+      "version": "6.0.1",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "../../../node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
     "../../../node_modules/update-browserslist-db": {
-      "version": "1.0.13",
+      "version": "1.2.3",
       "dev": true,
       "funding": [
         {
@@ -7844,8 +9679,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -7862,29 +9697,8 @@
         "punycode": "^2.1.0"
       }
     },
-    "../../../node_modules/url-parse": {
-      "version": "1.5.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
-    "../../../node_modules/util": {
-      "version": "0.12.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "../../../node_modules/uuid": {
-      "version": "10.0.0",
+      "version": "11.1.1",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -7892,7 +9706,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "../../../node_modules/v8-compile-cache-lib": {
@@ -7901,7 +9715,7 @@
       "license": "MIT"
     },
     "../../../node_modules/v8-to-istanbul": {
-      "version": "9.2.0",
+      "version": "9.3.0",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7914,14 +9728,14 @@
       }
     },
     "../../../node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "xml-name-validator": "^4.0.0"
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "../../../node_modules/walker": {
@@ -7932,35 +9746,16 @@
         "makeerror": "1.0.12"
       }
     },
-    "../../../node_modules/web-encoding": {
-      "version": "1.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "util": "^0.12.3"
-      },
-      "optionalDependencies": {
-        "@zxing/text-encoding": "0.9.0"
-      }
-    },
-    "../../../node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "../../../node_modules/webcrypto-core": {
-      "version": "1.8.0",
+      "version": "1.9.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.7.0",
         "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "../../../node_modules/webidl-conversions": {
@@ -7972,34 +9767,34 @@
       }
     },
     "../../../node_modules/whatwg-encoding": {
-      "version": "2.0.0",
+      "version": "3.1.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "../../../node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "../../../node_modules/whatwg-url": {
-      "version": "11.0.0",
+      "version": "14.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "../../../node_modules/which": {
@@ -8078,14 +9873,16 @@
       }
     },
     "../../../node_modules/which-typed-array": {
-      "version": "1.1.16",
+      "version": "1.1.19",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -8101,6 +9898,23 @@
       "license": "MIT"
     },
     "../../../node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "../../../node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
@@ -8116,25 +9930,73 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "../../../node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "../../../node_modules/wrappy": {
       "version": "1.0.2",
       "dev": true,
       "license": "ISC"
     },
     "../../../node_modules/write-file-atomic": {
-      "version": "4.0.2",
+      "version": "5.0.1",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "../../../node_modules/ws": {
-      "version": "8.17.1",
+      "version": "8.21.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8154,11 +10016,11 @@
       }
     },
     "../../../node_modules/xml-name-validator": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "../../../node_modules/xmlchars": {
@@ -8180,14 +10042,17 @@
       "license": "ISC"
     },
     "../../../node_modules/yaml": {
-      "version": "2.7.1",
+      "version": "2.8.3",
       "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "../../../node_modules/yargs": {
@@ -8215,6 +10080,43 @@
         "node": ">=12"
       }
     },
+    "../../../node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "../../../node_modules/yn": {
       "version": "3.1.1",
       "dev": true,
@@ -8234,10 +10136,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "../../../node_modules/zod": {
+      "version": "4.1.12",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "../../../node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "../../../node_modules/zwitch": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/@bergos/jsonparse": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.2.tgz",
-      "integrity": "sha512-qUt0QNJjvg4s1zk+AuLM6s/zcsQ8MvGn7+1f0vPuxvpCYa08YtTryuDInngbEyW5fNGGYe2znKt61RMGd5HnXg==",
       "engines": [
         "node >= 0.2.0"
       ],
@@ -8247,9 +10175,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8258,8 +10186,6 @@
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8349,6 +10275,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8364,6 +10293,9 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -8381,6 +10313,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8396,6 +10331,9 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -8413,6 +10351,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8424,10 +10365,11 @@
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -8445,6 +10387,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8456,10 +10401,11 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -8476,6 +10422,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -8499,6 +10448,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8520,6 +10472,9 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -8543,6 +10498,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8565,6 +10523,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8582,10 +10543,11 @@
     },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -8609,6 +10571,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -8626,10 +10591,11 @@
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -8735,14 +10701,10 @@
     },
     "node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/internal-playwright-testids": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-3.2.6.tgz",
-      "integrity": "sha512-6VjK81YqFeMyKjWQibjTJW5jpAe9X5JJTQ3eZDkTZfMwVBrozwU8A4kx6EC+ubiEdCWlhQulU3HjnL+TZaeF5A==",
       "license": "MIT"
     },
     "node_modules/@inrupt/internal-playwright-testids": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-4.1.3.tgz",
-      "integrity": "sha512-HgsFfptg+hWUoz5Hwzz3eTgJkPW/svoyI/jSeauwjeQUzYGt6dWjwyLXwa0Ql6K/1HlJLq1VMo9Q1gk1UWl+Og==",
       "license": "MIT"
     },
     "node_modules/@inrupt/internal-test-env": {
@@ -8757,8 +10719,6 @@
     },
     "node_modules/@inrupt/internal-test-env/node_modules/@inrupt/solid-client": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-2.1.2.tgz",
-      "integrity": "sha512-JCqWe2Kl0fVjBpd+Ntdjrd1rhv4v9NkiQI/PXE0wOhfmj/zNd45/qu8nGbpojfnUqopmBZSN2BU4dUpGy795nQ==",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client-errors": "^0.0.2",
@@ -8779,39 +10739,19 @@
     },
     "node_modules/@inrupt/internal-test-env/node_modules/@inrupt/solid-client-errors": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-errors/-/solid-client-errors-0.0.2.tgz",
-      "integrity": "sha512-Nhq39DJMKDMc35/VFT168v9JwuKzfzCHPN4fYYAE/Q0ECtM6PuBGT7nu0gZ06+S0pZQasHDyTkOGXRIx+zkvJA==",
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
       }
     },
     "node_modules/@inrupt/internal-test-env/node_modules/@rdfjs/types": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
-      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
-    "node_modules/@inrupt/internal-test-env/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/@inrupt/internal-test-env/node_modules/jsonld-streaming-parser": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-4.0.1.tgz",
-      "integrity": "sha512-6M4y9YGgADk3nXJebbRrxEdMVBJ9bnz+peAvjTXUievopqaE8sg/qml/I6Sp1ln7rpOKffsNZWSre6B7N76szw==",
       "license": "MIT",
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
@@ -8832,8 +10772,6 @@
     },
     "node_modules/@inrupt/internal-test-env/node_modules/rdf-data-factory": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
-      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^1.0.0"
@@ -8841,8 +10779,6 @@
     },
     "node_modules/@inrupt/oidc-client-ext": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-5.0.0.tgz",
-      "integrity": "sha512-NUfBd9UH40JpSiwTTeK+B4ige5zDYbIMGM5nvOZU4Axhn7Vn66AzJqNV6xJjRqG0G+zeHsAduyiyPydmA5+Ciw==",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client-authn-core": "^5.0.0",
@@ -8853,8 +10789,6 @@
     },
     "node_modules/@inrupt/oidc-client-ext/node_modules/@inrupt/solid-client-authn-core": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-5.0.0.tgz",
-      "integrity": "sha512-KYZCv8IO0ytDy3ApyVhiIsmWJY7Z+AXqmU3F+LtV3DBXxwZ9vF9YK8hOzf0ltPmVtqcf4RrnW5fIEtKmHmjuFQ==",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",
@@ -8867,8 +10801,6 @@
     },
     "node_modules/@inrupt/oidc-client-ext/node_modules/jose": {
       "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -8876,8 +10808,6 @@
     },
     "node_modules/@inrupt/oidc-client-ext/node_modules/uuid": {
       "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -8889,8 +10819,6 @@
     },
     "node_modules/@inrupt/solid-client": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-3.0.0.tgz",
-      "integrity": "sha512-QQCLakUeQldTAFewZZv7qlIotAlXnN1ZigRphr6SNKck2L9NAESWihba9i+9/AJLMnAPStx9XS+WuJswzlmhVA==",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client-errors": "^0.0.2",
@@ -8911,8 +10839,6 @@
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-5.0.0.tgz",
-      "integrity": "sha512-qdy8EfzwMsbvH7Wy1Ixx6rb27CTtTQyYJWzHVPDzg4Ln/aQo0zkjSTlnU7tT9VQZrMcarethZfTx5Z5ONwT77g==",
       "license": "MIT",
       "dependencies": {
         "@inrupt/oidc-client-ext": "^5.0.0",
@@ -8924,8 +10850,6 @@
     },
     "node_modules/@inrupt/solid-client-authn-browser/node_modules/@inrupt/solid-client-authn-core": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-5.0.0.tgz",
-      "integrity": "sha512-KYZCv8IO0ytDy3ApyVhiIsmWJY7Z+AXqmU3F+LtV3DBXxwZ9vF9YK8hOzf0ltPmVtqcf4RrnW5fIEtKmHmjuFQ==",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",
@@ -8938,8 +10862,6 @@
     },
     "node_modules/@inrupt/solid-client-authn-browser/node_modules/jose": {
       "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -8947,8 +10869,6 @@
     },
     "node_modules/@inrupt/solid-client-authn-browser/node_modules/uuid": {
       "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9011,30 +10931,12 @@
     },
     "node_modules/@inrupt/solid-client/node_modules/@inrupt/solid-client-errors": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-errors/-/solid-client-errors-0.0.2.tgz",
-      "integrity": "sha512-Nhq39DJMKDMc35/VFT168v9JwuKzfzCHPN4fYYAE/Q0ECtM6PuBGT7nu0gZ06+S0pZQasHDyTkOGXRIx+zkvJA==",
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
       }
     },
-    "node_modules/@inrupt/solid-client/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/@inrupt/solid-client/node_modules/uuid": {
       "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9050,8 +10952,6 @@
     },
     "node_modules/@next/env": {
       "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -9126,8 +11026,6 @@
     },
     "node_modules/@next/swc-linux-x64-gnu": {
       "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
       "cpu": [
         "x64"
       ],
@@ -9196,8 +11094,6 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
-      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -9232,8 +11128,6 @@
     },
     "node_modules/@rdfjs/types": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
-      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9248,8 +11142,6 @@
     },
     "node_modules/@types/http-link-header": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.7.tgz",
-      "integrity": "sha512-snm5oLckop0K3cTDAiBnZDy6ncx9DJ3mCRDvs42C884MbVYPP74Tiq2hFsSDRTyjK6RyDYDIulPiW23ge+g5Lw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9272,8 +11164,6 @@
     },
     "node_modules/@types/readable-stream": {
       "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
-      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9309,8 +11199,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -9358,8 +11246,6 @@
     },
     "node_modules/canonicalize": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
-      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
       "license": "Apache-2.0"
     },
     "node_modules/client-only": {
@@ -9380,8 +11266,6 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -9413,24 +11297,21 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/http-link-header": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
-      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -9463,8 +11344,6 @@
     },
     "node_modules/jsonld-context-parser": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.1.0.tgz",
-      "integrity": "sha512-BfgNJ/t9jjK7Lun9XRCJM6YeNqDk8B6/lg+KS8rzhXAOtS0FvoClSmtLvF24V1M2CDYRy2LcEBt0ilxqSX93WA==",
       "license": "MIT",
       "dependencies": {
         "@types/http-link-header": "^1.0.1",
@@ -9482,8 +11361,6 @@
     },
     "node_modules/jsonld-context-parser/node_modules/@types/node": {
       "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -9491,14 +11368,10 @@
     },
     "node_modules/jsonld-context-parser/node_modules/undici-types": {
       "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
     "node_modules/jsonld-streaming-parser": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-5.0.1.tgz",
-      "integrity": "sha512-Rf230DRAWe5p1H4e7phk1vo4FHEMOmC5xVcIywKJBBcwy6zaJWFcAvPcwngufNTdJs7dpTMbKQDjp4TYDpMKUQ==",
       "license": "MIT",
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
@@ -9518,8 +11391,6 @@
     },
     "node_modules/jwt-decode": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9565,8 +11436,6 @@
     },
     "node_modules/next": {
       "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
       "license": "MIT",
       "dependencies": {
         "@next/env": "16.2.9",
@@ -9625,8 +11494,6 @@
     },
     "node_modules/oidc-client-ts": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
-      "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^4.0.0"
@@ -9668,8 +11535,6 @@
     },
     "node_modules/playwright": {
       "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
-      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -9687,8 +11552,6 @@
     },
     "node_modules/playwright-core": {
       "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
-      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -9696,6 +11559,21 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -9751,8 +11629,6 @@
     },
     "node_modules/rdf-data-factory": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
-      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.0"
@@ -9764,8 +11640,6 @@
     },
     "node_modules/react": {
       "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9798,8 +11672,6 @@
     },
     "node_modules/relative-to-absolute-iri": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.8.tgz",
-      "integrity": "sha512-U1TmhrhCmXKkDL9mI8gBbF5TN6TKcuv28k5+H3gMCAjoz0TyyHAICHlaGDZsTEBSu2Y3HhDKc8e6X9n33qeIqA==",
       "license": "MIT",
       "funding": {
         "type": "individual",
@@ -9831,8 +11703,6 @@
     },
     "node_modules/semver": {
       "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -9844,8 +11714,6 @@
     },
     "node_modules/sharp": {
       "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,


### PR DESCRIPTION
This re-generates the lockfile for the e2e test directory by running `npm install` inside the e2e/browser/test-app directory